### PR TITLE
feat: 지식 공유 글 기능 1차 구현 (MVP)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ subprojects {
         add("testImplementation", "io.kotest:kotest-runner-junit5:$kotestVersion")
         add("testImplementation", "io.kotest:kotest-assertions-core:$kotestVersion")
         add("testImplementation", "io.kotest:kotest-property:$kotestVersion")
+        add("testImplementation", "io.kotest:kotest-framework-datatest:$kotestVersion")
 
         // mockk
         add("testImplementation", "io.mockk:mockk:1.13.11")

--- a/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
+++ b/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
@@ -45,11 +45,11 @@ class ArticleService(
 
     override fun create(writerId: Long, command: CreateCommand): Article {
         require(authRepositoryPort.existsById(writerId)) {
-            CustomException(AuthExceptionType.AUTH_NOT_FOUND)
+            throw CustomException(AuthExceptionType.AUTH_NOT_FOUND)
         }
 
         require(categoryRepositoryPort.existsById(command.categoryId)) {
-            CustomException(CategoryExceptionType.CATEGORY_NOT_FOUND)
+            throw CustomException(CategoryExceptionType.CATEGORY_NOT_FOUND)
         }
 
         return articleRepositoryPort.save(
@@ -71,7 +71,7 @@ class ArticleService(
     private fun findValidatedUpdatableArticle(memberId: Long, articleId: Long, isOnlyAdminAllowed: Boolean, categoryId: Long? = null): Article {
         categoryId?.let {
             require(categoryRepositoryPort.existsById(categoryId)) {
-                CustomException(CategoryExceptionType.CATEGORY_NOT_FOUND)
+                throw CustomException(CategoryExceptionType.CATEGORY_NOT_FOUND)
             }
         }
 

--- a/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
+++ b/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
@@ -69,7 +69,7 @@ class ArticleService(
             throw CustomException(ArticleExceptionType.MISMATCHED_ARTICLE_WRITER)
         }
 
-        if (member.role == Role.USER && article.isDeleted()) {
+        if (article.isDeleted()) {
             throw CustomException(ArticleExceptionType.ARTICLE_NOT_FOUND)
         }
 
@@ -77,7 +77,7 @@ class ArticleService(
     }
 
     override fun update(memberId: Long, articleId: Long, command: UpdateCommand): Article {
-        val article = validatedArticlePreModifyConditions(memberId = memberId, articleId = articleId)
+        val article = validatedArticlePreModifyConditions(memberId = memberId, articleId = articleId, categoryId = command.categoryId)
 
         val updatedArticle = article.update(
             categoryId = command.categoryId,

--- a/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
+++ b/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
@@ -7,7 +7,12 @@ import com.common.util.throwWhen
 import com.domain.article.Article
 import com.domain.article.dto.ArticleSimpleResponse
 import com.domain.article.dto.ArticlesSimpleResponse
+import com.domain.article.event.ArticleCreatedEvent
+import com.domain.article.event.ArticleDeletedEvent
+import com.domain.article.event.ArticleEvent
+import com.domain.article.event.ArticleUpdatedEvent
 import com.domain.article.exception.ArticleExceptionType
+import mu.KotlinLogging
 import com.domain.article.port.`in`.ArticleUseCase
 import com.domain.article.port.`in`.command.CreateCommand
 import com.domain.article.port.`in`.command.ReportCommand
@@ -18,6 +23,7 @@ import com.domain.auth.Auth
 import com.domain.auth.port.out.AuthRepositoryPort
 import com.domain.category.exception.CategoryExceptionType
 import com.domain.category.port.out.CategoryRepositoryPort
+import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
 
 @Service
@@ -26,6 +32,16 @@ class ArticleService(
     private val authRepositoryPort: AuthRepositoryPort,
     private val categoryRepositoryPort: CategoryRepositoryPort,
 ): ArticleUseCase {
+
+    // TODO 제거 예정
+    @EventListener(ArticleCreatedEvent::class, ArticleUpdatedEvent::class, ArticleDeletedEvent::class)
+    fun sendEvent(event: ArticleEvent) {
+        when (event) {
+            is ArticleCreatedEvent -> { log.debug { "Article 생성 완료 및 이벤트 발송 완료" } }
+            is ArticleUpdatedEvent -> { log.debug { "Article 수정 완료 및 이벤트 발송 완료" } }
+            is ArticleDeletedEvent -> { log.debug { "Article 삭제 완료 및 이벤트 발송 완료" } }
+        }
+    }
 
     override fun create(writerId: Long, command: CreateCommand): Article {
         require(authRepositoryPort.existsById(writerId)) {
@@ -131,5 +147,9 @@ class ArticleService(
         )
 
         return articlesResponse
+    }
+
+    companion object {
+        private val log = KotlinLogging.logger { }
     }
 }

--- a/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
+++ b/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
@@ -1,0 +1,131 @@
+package com.application.article
+
+import com.common.global.auth.role.Role
+import com.common.global.exceptions.base.CustomException
+import com.common.util.throwWhen
+import com.domain.article.Article
+import com.domain.article.dto.ArticleSimpleResponse
+import com.domain.article.dto.ArticlesSimpleResponse
+import com.domain.article.exception.ArticleExceptionType
+import com.domain.article.port.`in`.ArticleUseCase
+import com.domain.article.port.`in`.command.CreateCommand
+import com.domain.article.port.`in`.command.ReportCommand
+import com.domain.article.port.`in`.command.UpdateCommand
+import com.domain.article.port.`in`.query.ListArticleFindQuery
+import com.domain.article.port.out.ArticleRepositoryPort
+import com.domain.auth.Auth
+import com.domain.auth.exception.AuthExceptionType
+import com.domain.auth.port.out.AuthRepositoryPort
+import com.domain.category.exception.CategoryExceptionType
+import com.domain.category.port.out.CategoryRepositoryPort
+import org.springframework.stereotype.Service
+
+@Service
+class ArticleService(
+    private val articleRepositoryPort: ArticleRepositoryPort,
+    private val authRepositoryPort: AuthRepositoryPort,
+    private val categoryRepositoryPort: CategoryRepositoryPort,
+): ArticleUseCase {
+
+    override fun create(writerId: Long, command: CreateCommand): Article {
+        throwWhen(authRepositoryPort.findByIdOrNull(writerId) == null) {
+            CustomException(AuthExceptionType.AUTH_NOT_FOUND)
+        }
+
+        throwWhen(categoryRepositoryPort.findByIdOrNull(command.categoryId) == null) {
+            CustomException(CategoryExceptionType.CATEGORY_NOT_FOUND)
+        }
+
+        return articleRepositoryPort.save(
+            Article.createArticle(
+                title = command.title, content = command.content,
+                categoryId = command.categoryId, writerId = writerId,
+                isVisible = command.isVisible, isQuestion = command.isQuestion
+            )
+        )
+    }
+
+    override fun delete(memberId: Long, articleId: Long) {
+        val article = validatedArticlePreModifyConditions(memberId = memberId, articleId = articleId)
+
+        val deletedArticle = article.delete()
+        articleRepositoryPort.save(deletedArticle)
+    }
+
+    private fun validatedArticlePreModifyConditions(memberId: Long, articleId: Long, categoryId: Long? = null): Article {
+        categoryId?.let {
+            throwWhen(categoryRepositoryPort.findByIdOrNull(categoryId) == null) {
+                CustomException(CategoryExceptionType.CATEGORY_NOT_FOUND)
+            }
+        }
+
+        val member = authRepositoryPort.findByIdOrNull(memberId)
+            ?: throw CustomException(AuthExceptionType.AUTH_NOT_FOUND)
+
+        val article = articleRepositoryPort.findByIdOrNull(articleId)
+            ?: throw CustomException(ArticleExceptionType.ARTICLE_NOT_FOUND)
+
+        if (member.role !== Role.ADMIN && memberId != article.writerId) {
+            throw CustomException(ArticleExceptionType.MISMATCHED_ARTICLE_WRITER)
+        }
+
+        if (member.role == Role.USER && article.isDeleted()) {
+            throw CustomException(ArticleExceptionType.ARTICLE_NOT_FOUND)
+        }
+
+        return article
+    }
+
+    override fun update(memberId: Long, articleId: Long, command: UpdateCommand): Article {
+        val article = validatedArticlePreModifyConditions(memberId = memberId, articleId = articleId)
+
+        val updatedArticle = article.update(
+            categoryId = command.categoryId,
+            title = command.title, content = command.content,
+            isVisible = command.isVisible
+        )
+
+        return articleRepositoryPort.save(updatedArticle)
+    }
+
+    override fun report(memberId: Long, articleId: Long, command: ReportCommand) {
+        val article = validatedArticlePreModifyConditions(memberId = memberId, articleId = articleId)
+
+        val reportedArticle = article.updateReport(reportState = command.reportState)
+        articleRepositoryPort.save(reportedArticle)
+    }
+
+    override fun find(memberId: Long, articleId: Long): ArticleSimpleResponse {
+        val articleResponse = articleRepositoryPort.findArticleById(articleId = articleId)
+
+        val member = authRepositoryPort.findByIdOrNull(memberId)
+            ?: Auth.anonymousAuth()
+
+        throwWhen(member.role != Role.ADMIN && articleResponse.isDeleted) {
+            throw CustomException(ArticleExceptionType.ARTICLE_NOT_FOUND)
+        }
+
+        throwWhen(member.role != Role.ADMIN && memberId != articleResponse.writerId && !articleResponse.isVisible) {
+            throw CustomException(ArticleExceptionType.ARTICLE_NOT_FOUND)
+        }
+
+        return articleResponse
+    }
+
+    override fun findArticlesWithNoOffsetPaging(
+        memberId: Long,
+        query: ListArticleFindQuery
+    ): ArticlesSimpleResponse {
+        val articlesResponse = articleRepositoryPort.findArticleByQuery(
+            lastArticleId = query.lastArticleId,
+            size = query.size,
+            categories = query.categories,
+            sort = query.sort,
+            direction = query.direction,
+            isQuestion = query.isQuestion,
+            isTrending = query.isTrending,
+        )
+
+        return articlesResponse
+    }
+}

--- a/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
+++ b/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
@@ -1,5 +1,6 @@
 package com.application.article
 
+import com.common.global.auth.exception.AuthExceptionType
 import com.common.global.auth.role.Role
 import com.common.global.exceptions.base.CustomException
 import com.common.util.throwWhen
@@ -14,7 +15,6 @@ import com.domain.article.port.`in`.command.UpdateCommand
 import com.domain.article.port.`in`.query.ListArticleFindQuery
 import com.domain.article.port.out.ArticleRepositoryPort
 import com.domain.auth.Auth
-import com.domain.auth.exception.AuthExceptionType
 import com.domain.auth.port.out.AuthRepositoryPort
 import com.domain.category.exception.CategoryExceptionType
 import com.domain.category.port.out.CategoryRepositoryPort
@@ -46,13 +46,13 @@ class ArticleService(
     }
 
     override fun delete(memberId: Long, articleId: Long) {
-        val article = validatedArticlePreModifyConditions(memberId = memberId, articleId = articleId)
+        val article = validatedArticlePreModifyConditions(memberId = memberId, articleId = articleId, isOnlyAdminAllowed = false)
 
         val deletedArticle = article.delete()
         articleRepositoryPort.save(deletedArticle)
     }
 
-    private fun validatedArticlePreModifyConditions(memberId: Long, articleId: Long, categoryId: Long? = null): Article {
+    private fun validatedArticlePreModifyConditions(memberId: Long, articleId: Long, isOnlyAdminAllowed: Boolean, categoryId: Long? = null): Article {
         categoryId?.let {
             throwWhen(categoryRepositoryPort.findByIdOrNull(categoryId) == null) {
                 CustomException(CategoryExceptionType.CATEGORY_NOT_FOUND)
@@ -69,7 +69,11 @@ class ArticleService(
             throw CustomException(ArticleExceptionType.MISMATCHED_ARTICLE_WRITER)
         }
 
-        if (article.isDeleted()) {
+        if (member.role !== Role.ADMIN && isOnlyAdminAllowed) {
+            throw CustomException(AuthExceptionType.INSUFFICIENT_ROLE)
+        }
+
+        if (member.role !== Role.ADMIN && article.isDeleted()) {
             throw CustomException(ArticleExceptionType.ARTICLE_NOT_FOUND)
         }
 
@@ -77,7 +81,7 @@ class ArticleService(
     }
 
     override fun update(memberId: Long, articleId: Long, command: UpdateCommand): Article {
-        val article = validatedArticlePreModifyConditions(memberId = memberId, articleId = articleId, categoryId = command.categoryId)
+        val article = validatedArticlePreModifyConditions(memberId = memberId, articleId = articleId, isOnlyAdminAllowed = false, categoryId = command.categoryId)
 
         val updatedArticle = article.update(
             categoryId = command.categoryId,
@@ -89,7 +93,7 @@ class ArticleService(
     }
 
     override fun report(memberId: Long, articleId: Long, command: ReportCommand) {
-        val article = validatedArticlePreModifyConditions(memberId = memberId, articleId = articleId)
+        val article = validatedArticlePreModifyConditions(memberId = memberId, articleId = articleId, isOnlyAdminAllowed = true)
 
         val reportedArticle = article.updateReport(reportState = command.reportState)
         articleRepositoryPort.save(reportedArticle)

--- a/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
+++ b/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
@@ -46,15 +46,15 @@ class ArticleService(
     }
 
     override fun delete(memberId: Long, articleId: Long) {
-        val article = validatedArticlePreModifyConditions(memberId = memberId, articleId = articleId, isOnlyAdminAllowed = false)
+        val article = findValidatedUpdatableArticle(memberId = memberId, articleId = articleId, isOnlyAdminAllowed = false)
 
         val deletedArticle = article.delete()
         articleRepositoryPort.save(deletedArticle)
     }
 
-    private fun validatedArticlePreModifyConditions(memberId: Long, articleId: Long, isOnlyAdminAllowed: Boolean, categoryId: Long? = null): Article {
+    private fun findValidatedUpdatableArticle(memberId: Long, articleId: Long, isOnlyAdminAllowed: Boolean, categoryId: Long? = null): Article {
         categoryId?.let {
-            throwWhen(categoryRepositoryPort.findByIdOrNull(categoryId) == null) {
+            require(categoryRepositoryPort.existsById(categoryId)) {
                 CustomException(CategoryExceptionType.CATEGORY_NOT_FOUND)
             }
         }
@@ -81,7 +81,7 @@ class ArticleService(
     }
 
     override fun update(memberId: Long, articleId: Long, command: UpdateCommand): Article {
-        val article = validatedArticlePreModifyConditions(memberId = memberId, articleId = articleId, isOnlyAdminAllowed = false, categoryId = command.categoryId)
+        val article = findValidatedUpdatableArticle(memberId = memberId, articleId = articleId, isOnlyAdminAllowed = false, categoryId = command.categoryId)
 
         val updatedArticle = article.update(
             categoryId = command.categoryId,
@@ -93,7 +93,7 @@ class ArticleService(
     }
 
     override fun report(memberId: Long, articleId: Long, command: ReportCommand) {
-        val article = validatedArticlePreModifyConditions(memberId = memberId, articleId = articleId, isOnlyAdminAllowed = true)
+        val article = findValidatedUpdatableArticle(memberId = memberId, articleId = articleId, isOnlyAdminAllowed = true)
 
         val reportedArticle = article.updateReport(reportState = command.reportState)
         articleRepositoryPort.save(reportedArticle)

--- a/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
+++ b/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
@@ -99,7 +99,7 @@ class ArticleService(
         articleRepositoryPort.save(reportedArticle)
     }
 
-    override fun find(memberId: Long, articleId: Long): ArticleSimpleResponse {
+    override fun findVisibleArticle(memberId: Long, articleId: Long): ArticleSimpleResponse {
         val articleResponse = articleRepositoryPort.findArticleById(articleId = articleId)
 
         val member = authRepositoryPort.findByIdOrNull(memberId)

--- a/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
+++ b/hunmin-application/src/main/kotlin/com/application/article/ArticleService.kt
@@ -28,11 +28,11 @@ class ArticleService(
 ): ArticleUseCase {
 
     override fun create(writerId: Long, command: CreateCommand): Article {
-        throwWhen(authRepositoryPort.findByIdOrNull(writerId) == null) {
+        require(authRepositoryPort.existsById(writerId)) {
             CustomException(AuthExceptionType.AUTH_NOT_FOUND)
         }
 
-        throwWhen(categoryRepositoryPort.findByIdOrNull(command.categoryId) == null) {
+        require(categoryRepositoryPort.existsById(command.categoryId)) {
             CustomException(CategoryExceptionType.CATEGORY_NOT_FOUND)
         }
 

--- a/hunmin-application/src/test/kotlin/com/application/article/ArticleServiceTest.kt
+++ b/hunmin-application/src/test/kotlin/com/application/article/ArticleServiceTest.kt
@@ -325,7 +325,7 @@ class ArticleServiceTest : BehaviorSpec({
 
             Then("예외가 발생한다") {
                 assertThatThrownBy {
-                    articleService.find(memberId = -1L, articleId = 1L)
+                    articleService.findVisibleArticle(memberId = -1L, articleId = 1L)
                 }.isInstanceOf(CustomException::class.java)
                     .hasMessageContaining(ARTICLE_NOT_FOUND.message)
             }
@@ -337,7 +337,7 @@ class ArticleServiceTest : BehaviorSpec({
 
             Then("예외가 발생한다") {
                 assertThatThrownBy {
-                    articleService.find(memberId = -1L, articleId = 1L)
+                    articleService.findVisibleArticle(memberId = -1L, articleId = 1L)
                 }.isInstanceOf(CustomException::class.java)
                     .hasMessageContaining(ARTICLE_NOT_FOUND.message)
             }
@@ -349,7 +349,7 @@ class ArticleServiceTest : BehaviorSpec({
 
             Then("예외가 발생한다") {
                 assertThatThrownBy {
-                    articleService.find(memberId = 1L, articleId = 1L)
+                    articleService.findVisibleArticle(memberId = 1L, articleId = 1L)
                 }.isInstanceOf(CustomException::class.java)
                     .hasMessageContaining(ARTICLE_NOT_FOUND.message)
             }
@@ -361,7 +361,7 @@ class ArticleServiceTest : BehaviorSpec({
 
             Then("예외가 발생한다") {
                 assertThatThrownBy {
-                    articleService.find(memberId = -1L, articleId = 1L)
+                    articleService.findVisibleArticle(memberId = -1L, articleId = 1L)
                 }.isInstanceOf(CustomException::class.java)
                     .hasMessageContaining(ARTICLE_NOT_FOUND.message)
             }
@@ -373,7 +373,7 @@ class ArticleServiceTest : BehaviorSpec({
 
             Then("예외가 발생한다") {
                 assertThatThrownBy {
-                    articleService.find(memberId = 1L, articleId = 1L)
+                    articleService.findVisibleArticle(memberId = 1L, articleId = 1L)
                 }.isInstanceOf(CustomException::class.java)
                     .hasMessageContaining(ARTICLE_NOT_FOUND.message)
             }
@@ -384,7 +384,7 @@ class ArticleServiceTest : BehaviorSpec({
             every { articleRepositoryPort.findArticleById(any()) } returns 일반_글_응답_생성()
 
             Then("조회 가능하다") {
-                val article = articleService.find(memberId = -1L, articleId = 1L)
+                val article = articleService.findVisibleArticle(memberId = -1L, articleId = 1L)
 
                 assertSoftly {
                     article.title shouldBe "일반 글"
@@ -400,7 +400,7 @@ class ArticleServiceTest : BehaviorSpec({
             every { articleRepositoryPort.findArticleById(any()) } returns 숨김_글_응답_생성_작성자id(1L)
 
             Then("조회 가능하다") {
-                val article = articleService.find(memberId = 1L, articleId = 1L)
+                val article = articleService.findVisibleArticle(memberId = 1L, articleId = 1L)
 
                 assertSoftly {
                     article.title shouldBe "숨김 글"
@@ -416,7 +416,7 @@ class ArticleServiceTest : BehaviorSpec({
             every { articleRepositoryPort.findArticleById(any()) } returns 숨김_글_응답_생성_작성자id(1L)
 
             Then("조회 가능하다") {
-                val article = articleService.find(memberId = 2L, articleId = 1L)
+                val article = articleService.findVisibleArticle(memberId = 2L, articleId = 1L)
 
                 assertSoftly {
                     article.title shouldBe "숨김 글"
@@ -432,7 +432,7 @@ class ArticleServiceTest : BehaviorSpec({
             every { articleRepositoryPort.findArticleById(any()) } returns 삭제_글_응답_생성()
 
             Then("조회 가능하다") {
-                val article = articleService.find(memberId = 2L, articleId = 1L)
+                val article = articleService.findVisibleArticle(memberId = 2L, articleId = 1L)
 
                 assertSoftly {
                     article.title shouldBe "삭제 글"

--- a/hunmin-application/src/test/kotlin/com/application/article/ArticleServiceTest.kt
+++ b/hunmin-application/src/test/kotlin/com/application/article/ArticleServiceTest.kt
@@ -1,10 +1,8 @@
 package com.application.article
 
 import com.application.article.ArticleCommandFixture.Companion.일반_글_생성_커맨드
-import com.application.auth.AuthCommandFixture.Companion.인증_생성
 import com.application.auth.AuthCommandFixture.Companion.인증_생성_id
 import com.application.auth.AuthCommandFixture.Companion.인증_생성_어드민_id
-import com.application.category.CategoryCommandFixture.Companion.카테고리_생성
 import com.common.global.auth.exception.AuthExceptionType.INSUFFICIENT_ROLE
 import com.common.global.exceptions.base.CustomException
 import com.domain.article.ArticleFixture.Companion.삭제_글_생성_작성자id
@@ -52,7 +50,7 @@ class ArticleServiceTest : BehaviorSpec({
     Given("글 생성을 할 때") {
 
         When("회원 정보가 없으면") {
-            every { authRepositoryPort.findByIdOrNull(any()) } returns null
+            every { authRepositoryPort.existsById(any()) } returns false
 
             Then("예외가 발생한다") {
                 assertThatThrownBy {
@@ -63,8 +61,8 @@ class ArticleServiceTest : BehaviorSpec({
         }
 
         When("카테고리 정보가 없으면") {
-            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(1L)
-            every { categoryRepositoryPort.findByIdOrNull(any()) } returns null
+            every { authRepositoryPort.existsById(any()) } returns true
+            every { categoryRepositoryPort.existsById(any()) } returns false
 
             Then("예외가 발생한다") {
                 assertThatThrownBy {
@@ -75,8 +73,8 @@ class ArticleServiceTest : BehaviorSpec({
         }
 
         When("회원 정보와 카테고리 정보가 모두 있으면") {
-            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성()
-            every { categoryRepositoryPort.findByIdOrNull(any()) } returns 카테고리_생성(createdAt = 1000)
+            every { authRepositoryPort.existsById(any()) } returns true
+            every { categoryRepositoryPort.existsById(any()) } returns true
             every { articleRepositoryPort.save(any()) } returns 일반_글_생성()
 
             Then("정상 생성된다") {
@@ -97,7 +95,7 @@ class ArticleServiceTest : BehaviorSpec({
     Given("글 삭제를 할 때") {
 
         When("회원 정보가 없으면") {
-            every { authRepositoryPort.findByIdOrNull(any()) } returns null
+            every { authRepositoryPort.existsById(any()) } returns false
 
             Then("예외가 발생한다") {
                 assertThatThrownBy {
@@ -179,7 +177,7 @@ class ArticleServiceTest : BehaviorSpec({
         When("변경할 대상의 카테고리가 없으면") {
             every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(1L)
             every { articleRepositoryPort.findByIdOrNull(any()) } returns 일반_글_생성_작성자id(1L)
-            every { categoryRepositoryPort.findByIdOrNull(any()) } returns null
+            every { categoryRepositoryPort.existsById(any()) } returns false
 
             Then("예외가 발생한다") {
                 assertThatThrownBy {

--- a/hunmin-application/src/test/kotlin/com/application/article/ArticleServiceTest.kt
+++ b/hunmin-application/src/test/kotlin/com/application/article/ArticleServiceTest.kt
@@ -15,6 +15,10 @@ import com.domain.article.ArticleFixture.Companion.일반_글_생성_신고처�
 import com.domain.article.ArticleFixture.Companion.일반_글_생성_작성자id
 import com.domain.article.ArticleFixture.Companion.일반_글_응답_생성
 import com.domain.article.ArticleFixture.Companion.일반_글_페이징_생성
+import com.domain.article.event.ArticleCreatedEvent
+import com.domain.article.event.ArticleDeletedEvent
+import com.domain.article.event.ArticleUpdatedEvent
+import io.kotest.datatest.withData
 import com.domain.article.exception.ArticleExceptionType.ALREADY_DELETED_ARTICLE
 import com.domain.article.exception.ArticleExceptionType.ARTICLE_NOT_FOUND
 import com.domain.article.exception.ArticleExceptionType.MISMATCHED_ARTICLE_WRITER
@@ -32,6 +36,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import mu.KotlinLogging
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.assertDoesNotThrow
 
@@ -42,6 +47,7 @@ class ArticleServiceTest : BehaviorSpec({
     val categoryRepositoryPort: CategoryRepositoryPort = mockk()
 
     val articleService = ArticleService(articleRepositoryPort, authRepositoryPort, categoryRepositoryPort)
+    val logger = KotlinLogging.logger {}
 
     Given("글 생성을 할 때") {
 
@@ -455,6 +461,24 @@ class ArticleServiceTest : BehaviorSpec({
             Then("ArticlesSimpleResponse가 반환된다") {
                 result shouldBe response
                 verify { articleRepositoryPort.findArticleByQuery(lastArticleId = 0L, size = 10, categories = listOf(1L), sort = "createdAt", direction = "DESC", isQuestion = false, isTrending = true) }
+            }
+        }
+    }
+
+    Given("ArticleEvent가 주어졌을 때") {
+        withData(
+            nameFn = { it::class.simpleName ?: "UnknownEvent" },
+            ArticleCreatedEvent(articleId = 1L, createdDateTime = 1234567890L),
+            ArticleUpdatedEvent(articleId = 2L, updatedDateTime = 1234567890L),
+            ArticleDeletedEvent(articleId = 3L, deletedDateTime = 1234567890L)
+        ) { event ->
+
+            When("sendEvent를 호출하면") {
+                articleService.sendEvent(event)
+
+                Then("이벤트 수신 로그가 출력된다") {
+                    logger.debug { "이벤트 수신 로그 확인: $event" }
+                }
             }
         }
     }

--- a/hunmin-application/src/test/kotlin/com/application/article/ArticleServiceTest.kt
+++ b/hunmin-application/src/test/kotlin/com/application/article/ArticleServiceTest.kt
@@ -1,18 +1,26 @@
 package com.application.article
 
-import com.application.article.ArticleCommandFixture.Companion.삭제_글_생성_작성자id
-import com.application.article.ArticleCommandFixture.Companion.일반_글_생성
-import com.application.article.ArticleCommandFixture.Companion.일반_글_생성_신고처리
-import com.application.article.ArticleCommandFixture.Companion.일반_글_생성_작성자id
 import com.application.article.ArticleCommandFixture.Companion.일반_글_생성_커맨드
 import com.application.auth.AuthCommandFixture.Companion.인증_생성
 import com.application.auth.AuthCommandFixture.Companion.인증_생성_id
 import com.application.auth.AuthCommandFixture.Companion.인증_생성_어드민_id
 import com.application.category.CategoryCommandFixture.Companion.카테고리_생성
+import com.common.global.auth.exception.AuthExceptionType.INSUFFICIENT_ROLE
 import com.common.global.exceptions.base.CustomException
+import com.domain.article.ArticleFixture.Companion.삭제_글_생성_작성자id
+import com.domain.article.ArticleFixture.Companion.삭제_글_응답_생성
+import com.domain.article.ArticleFixture.Companion.숨김_글_응답_생성_작성자id
+import com.domain.article.ArticleFixture.Companion.일반_글_생성
+import com.domain.article.ArticleFixture.Companion.일반_글_생성_신고처리
+import com.domain.article.ArticleFixture.Companion.일반_글_생성_작성자id
+import com.domain.article.ArticleFixture.Companion.일반_글_응답_생성
+import com.domain.article.ArticleFixture.Companion.일반_글_페이징_생성
+import com.domain.article.exception.ArticleExceptionType.ALREADY_DELETED_ARTICLE
 import com.domain.article.exception.ArticleExceptionType.ARTICLE_NOT_FOUND
 import com.domain.article.exception.ArticleExceptionType.MISMATCHED_ARTICLE_WRITER
 import com.domain.article.port.`in`.command.ReportCommand
+import com.domain.article.port.`in`.command.UpdateCommand
+import com.domain.article.port.`in`.query.ListArticleFindQuery
 import com.domain.article.port.out.ArticleRepositoryPort
 import com.domain.auth.exception.AuthExceptionType.AUTH_NOT_FOUND
 import com.domain.auth.port.out.AuthRepositoryPort
@@ -23,6 +31,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.assertDoesNotThrow
 
@@ -39,7 +48,7 @@ class ArticleServiceTest : BehaviorSpec({
         When("회원 정보가 없으면") {
             every { authRepositoryPort.findByIdOrNull(any()) } returns null
 
-            Then("예외를 발생시킨다") {
+            Then("예외가 발생한다") {
                 assertThatThrownBy {
                     articleService.create(writerId = 1L, command = 일반_글_생성_커맨드())
                 }.isInstanceOf(CustomException::class.java)
@@ -51,7 +60,7 @@ class ArticleServiceTest : BehaviorSpec({
             every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(1L)
             every { categoryRepositoryPort.findByIdOrNull(any()) } returns null
 
-            Then("예외를 발생시킨다") {
+            Then("예외가 발생한다") {
                 assertThatThrownBy {
                     articleService.create(writerId = 1L, command = 일반_글_생성_커맨드())
                 }.isInstanceOf(CustomException::class.java)
@@ -84,7 +93,7 @@ class ArticleServiceTest : BehaviorSpec({
         When("회원 정보가 없으면") {
             every { authRepositoryPort.findByIdOrNull(any()) } returns null
 
-            Then("예외를 발생시킨다") {
+            Then("예외가 발생한다") {
                 assertThatThrownBy {
                     articleService.create(writerId = 0L, command = 일반_글_생성_커맨드())
                 }.isInstanceOf(CustomException::class.java)
@@ -96,7 +105,7 @@ class ArticleServiceTest : BehaviorSpec({
             every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(0L)
             every { articleRepositoryPort.findByIdOrNull(any()) } returns null
 
-            Then("예외를 발생시킨다") {
+            Then("예외가 발생한다") {
                 assertThatThrownBy {
                     articleService.delete(memberId = 0L, articleId = 1L)
                 }.isInstanceOf(CustomException::class.java)
@@ -108,7 +117,7 @@ class ArticleServiceTest : BehaviorSpec({
             every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(2L)
             every { articleRepositoryPort.findByIdOrNull(any()) } returns 일반_글_생성()
 
-            Then("예외를 발생시킨다") {
+            Then("예외가 발생한다") {
                 assertThatThrownBy {
                     articleService.delete(memberId = 2L, articleId = 0L)
                 }.isInstanceOf(CustomException::class.java)
@@ -120,7 +129,7 @@ class ArticleServiceTest : BehaviorSpec({
             every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(2L)
             every { articleRepositoryPort.findByIdOrNull(any()) } returns 삭제_글_생성_작성자id(2L)
 
-            Then("예외를 발생시킨다") {
+            Then("예외가 발생한다") {
                 assertThatThrownBy {
                     articleService.delete(memberId = 2L, articleId = 1L)
                 }.isInstanceOf(CustomException::class.java)
@@ -132,11 +141,11 @@ class ArticleServiceTest : BehaviorSpec({
             every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(2L)
             every { articleRepositoryPort.findByIdOrNull(any()) } returns 삭제_글_생성_작성자id(2L)
 
-            Then("예외를 발생시킨다") {
+            Then("예외가 발생한다") {
                 assertThatThrownBy {
                     articleService.delete(memberId = 2L, articleId = 1L)
                 }.isInstanceOf(CustomException::class.java)
-                    .hasMessageContaining(ARTICLE_NOT_FOUND.message)
+                    .hasMessageContaining(ALREADY_DELETED_ARTICLE.message)
             }
         }
 
@@ -160,7 +169,92 @@ class ArticleServiceTest : BehaviorSpec({
     }
 
     Given("글 수정을 할 때") {
-        // TODO
+
+        When("변경할 대상의 카테고리가 없으면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(1L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns 일반_글_생성_작성자id(1L)
+            every { categoryRepositoryPort.findByIdOrNull(any()) } returns null
+
+            Then("예외가 발생한다") {
+                assertThatThrownBy {
+                    articleService.update(memberId = 1L, articleId = 1L, command = UpdateCommand(categoryId = 2L))
+                }
+            }
+        }
+
+        When("회원 정보가 없으면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns null
+
+            Then("예외가 발생한다") {
+                assertThatThrownBy {
+                    articleService.update(memberId = -1L, articleId = 1L, command = UpdateCommand(title = "수정 글"))
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(AUTH_NOT_FOUND.message)
+            }
+        }
+
+        When("글 정보가 없으면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(1L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns null
+
+            Then("예외가 발생한다") {
+                assertThatThrownBy {
+                    articleService.update(memberId = 1L, articleId = 1L, command = UpdateCommand(title = "수정 글"))
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(ARTICLE_NOT_FOUND.message)
+            }
+        }
+
+        When("일반 유저이면서 작성자가 아니면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(2L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns 일반_글_생성_작성자id(1L)
+
+            Then("예외가 발생한다") {
+                assertThatThrownBy {
+                    articleService.update(memberId = 2L, articleId = 1L, command = UpdateCommand(title = "수정 글"))
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(MISMATCHED_ARTICLE_WRITER.message)
+            }
+        }
+
+        When("작성자이면서 삭제된 상태면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(1L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns 삭제_글_생성_작성자id(1L)
+
+            Then("예외가 발생한다") {
+                assertThatThrownBy {
+                    articleService.update(memberId = 1L, articleId = 1L, command = UpdateCommand(title = "수정 글"))
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(ARTICLE_NOT_FOUND.message)
+            }
+        }
+
+        When("작성자이면서 삭제된 상태가 아니면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(1L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns 일반_글_생성_작성자id(1L)
+
+            Then("예외가 발생하지 않는다") {
+                assertDoesNotThrow { articleService.update(memberId = 1L, articleId = 1L, command = UpdateCommand(title = "수정 글")) }
+            }
+        }
+
+        When("어드민이면서 작성자가 아니면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(1L)
+            every { articleRepositoryPort.findByIdOrNull((any())) } returns 일반_글_생성_작성자id(2L)
+
+            Then("예외가 발생하지 않는다") {
+                assertDoesNotThrow { articleService.update(memberId = 1L, articleId = 1L, command = UpdateCommand(title = "수정 글")) }
+            }
+        }
+
+        When("어드민이고 삭제된 상태면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(1L)
+            every { articleRepositoryPort.findByIdOrNull((any())) } returns 삭제_글_생성_작성자id(2L)
+
+            Then("예외가 발생하지 않는다") {
+                assertDoesNotThrow { articleService.update(memberId = 1L, articleId = 1L, command = UpdateCommand(title = "수정 글")) }
+            }
+        }
     }
 
     Given("글 신고를 할 때") {
@@ -168,31 +262,31 @@ class ArticleServiceTest : BehaviorSpec({
         When("회원 정보가 없으면") {
             every { authRepositoryPort.findByIdOrNull(any()) } returns null
 
-            Then("예외를 발생시킨다") {
+            Then("예외가 발생한다") {
                 assertThatThrownBy {
-                    articleService.report(memberId = 0L, articleId = 0L, command = ReportCommand(reason = "신고 들어옴"))
+                    articleService.report(memberId = -1L, articleId = 0L, command = ReportCommand(reason = "신고 들어옴"))
                 }.isInstanceOf(CustomException::class.java)
                     .hasMessageContaining(AUTH_NOT_FOUND.message)
             }
         }
 
         When("글 정보가 없으면") {
-            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(0L)
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(1L)
             every { articleRepositoryPort.findByIdOrNull(any()) } returns null
 
-            Then("예외를 발생시킨다") {
+            Then("어드민이더라도 예외가 발생한다") {
                 assertThatThrownBy {
-                    articleService.report(memberId = 0L, articleId = 1L, command = ReportCommand(reason = "신고 들어옴"))
+                    articleService.report(memberId = 1L, articleId = 1L, command = ReportCommand(reason = "신고 들어옴"))
                 }.isInstanceOf(CustomException::class.java)
                     .hasMessageContaining(ARTICLE_NOT_FOUND.message)
             }
         }
 
-        When("어드민이 아니면") {
+        When("어드민이 아니고 일반 유저면") {
             every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(2L)
             every { articleRepositoryPort.findByIdOrNull(any()) } returns 일반_글_생성()
 
-            Then("예외를 발생시킨다") {
+            Then("예외가 발생한다") {
                 assertThatThrownBy {
                     articleService.report(memberId = 2L, articleId = 0L, command = ReportCommand(reason = "신고 들어옴"))
                 }.isInstanceOf(CustomException::class.java)
@@ -200,19 +294,19 @@ class ArticleServiceTest : BehaviorSpec({
             }
         }
 
-        When("이미 삭제된 글이면 어드민이더라도") {
-            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(2L)
-            every { articleRepositoryPort.findByIdOrNull(any()) } returns 삭제_글_생성_작성자id(2L)
+        When("어드민이 아니고 작성자면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(2L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns 일반_글_생성_작성자id(2L)
 
-            Then("예외를 발생시킨다") {
+            Then("예외가 발생한다") {
                 assertThatThrownBy {
                     articleService.report(memberId = 2L, articleId = 0L, command = ReportCommand(reason = "신고 들어옴"))
                 }.isInstanceOf(CustomException::class.java)
-                    .hasMessageContaining(ARTICLE_NOT_FOUND.message)
+                    .hasMessageContaining(INSUFFICIENT_ROLE.message)
             }
         }
 
-        When("어드민이면서 작성자가 아니고, 삭제되지 않았으면") {
+        When("어드민이면서 작성자가 아니면") {
             every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(2L)
             every { articleRepositoryPort.findByIdOrNull(any()) } returns 일반_글_생성()
             every { articleRepositoryPort.save(any()) } returns 일반_글_생성_신고처리()
@@ -226,7 +320,32 @@ class ArticleServiceTest : BehaviorSpec({
     Given("글 단건 조회를 할 때") {
 
         When("익명 / 일반 유저 / 작성자 / 어드민 상관없이, 글 정보가 아예 없으면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns null
             every { articleRepositoryPort.findArticleById(any()) } throws CustomException(ARTICLE_NOT_FOUND)
+
+            Then("예외가 발생한다") {
+                assertThatThrownBy {
+                    articleService.find(memberId = -1L, articleId = 1L)
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(ARTICLE_NOT_FOUND.message)
+            }
+        }
+
+        When("익명일 때, 삭제된 상태면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns null
+            every { articleRepositoryPort.findArticleById(any()) } returns 삭제_글_응답_생성()
+
+            Then("예외가 발생한다") {
+                assertThatThrownBy {
+                    articleService.find(memberId = -1L, articleId = 1L)
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(ARTICLE_NOT_FOUND.message)
+            }
+        }
+
+        When("어드민이 아닐 때, 작성자 / 일반 유저더라도 삭제된 상태면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(1L)
+            every { articleRepositoryPort.findArticleById(any()) } returns 삭제_글_응답_생성()
 
             Then("예외가 발생한다") {
                 assertThatThrownBy {
@@ -236,40 +355,107 @@ class ArticleServiceTest : BehaviorSpec({
             }
         }
 
-        // TODO
-        When("익명일 때, 삭제된 상태면") {
-
-            Then("예외가 발생한다") {
-
-            }
-        }
-
-        // TODO
-        When("어드민이 아닐 때, 작성자 / 일반 유저더라도 삭제된 상태면") {
-
-            Then("예외가 발생한다") {
-
-            }
-        }
-
-        // TODO
         When("익명일 때, 숨김 처리된 글이면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns null
+            every { articleRepositoryPort.findArticleById(any()) } returns 숨김_글_응답_생성_작성자id(2L)
 
             Then("예외가 발생한다") {
-
+                assertThatThrownBy {
+                    articleService.find(memberId = -1L, articleId = 1L)
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(ARTICLE_NOT_FOUND.message)
             }
         }
 
-        // TODO
         When("일반 유저일 때, 숨김 처리된 글이면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(2L)
+            every { articleRepositoryPort.findArticleById(any()) } returns 숨김_글_응답_생성_작성자id(2L)
 
             Then("예외가 발생한다") {
+                assertThatThrownBy {
+                    articleService.find(memberId = 1L, articleId = 1L)
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(ARTICLE_NOT_FOUND.message)
+            }
+        }
 
+        When("익명 / 일반 유저일 때, 글이 존재하고 볼 수 있는 상태면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns null
+            every { articleRepositoryPort.findArticleById(any()) } returns 일반_글_응답_생성()
+
+            Then("조회 가능하다") {
+                val article = articleService.find(memberId = -1L, articleId = 1L)
+
+                assertSoftly {
+                    article.title shouldBe "일반 글"
+                    article.content shouldBe "일반 글 내용"
+                    article.isVisible shouldBe true
+                    article.isDeleted shouldBe false
+                }
+            }
+        }
+
+        When("작성자일 때, 숨김 처리된 글이면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(1L)
+            every { articleRepositoryPort.findArticleById(any()) } returns 숨김_글_응답_생성_작성자id(1L)
+
+            Then("조회 가능하다") {
+                val article = articleService.find(memberId = 1L, articleId = 1L)
+
+                assertSoftly {
+                    article.title shouldBe "숨김 글"
+                    article.content shouldBe "숨김 글 내용"
+                    article.isVisible shouldBe false
+                    article.isDeleted shouldBe false
+                }
+            }
+        }
+
+        When("어드민일 때, 숨김 처리된 글이면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(2L)
+            every { articleRepositoryPort.findArticleById(any()) } returns 숨김_글_응답_생성_작성자id(1L)
+
+            Then("조회 가능하다") {
+                val article = articleService.find(memberId = 2L, articleId = 1L)
+
+                assertSoftly {
+                    article.title shouldBe "숨김 글"
+                    article.content shouldBe "숨김 글 내용"
+                    article.isVisible shouldBe false
+                    article.isDeleted shouldBe false
+                }
+            }
+        }
+
+        When("어드민일 때, 삭제된 글이면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(2L)
+            every { articleRepositoryPort.findArticleById(any()) } returns 삭제_글_응답_생성()
+
+            Then("조회 가능하다") {
+                val article = articleService.find(memberId = 2L, articleId = 1L)
+
+                assertSoftly {
+                    article.title shouldBe "삭제 글"
+                    article.content shouldBe "삭제 글 내용"
+                    article.isVisible shouldBe false
+                    article.isDeleted shouldBe true
+                }
             }
         }
     }
 
     Given("글 목록 조회를 할 때") {
-        // TODO
+        val response = 일반_글_페이징_생성()
+
+        When("findArticlesWithNoOffsetPaging를 호출하면") {
+            every { articleRepositoryPort.findArticleByQuery(0L, 10, listOf(1L), any(), any(), any(), any()) } returns response
+            val query = ListArticleFindQuery(lastArticleId = 0L, size = 10, categories = listOf(1L), sort = "createdAt", direction = "DESC", isQuestion = false, isTrending = true)
+            val result = articleService.findArticlesWithNoOffsetPaging(1L, query)
+
+            Then("ArticlesSimpleResponse가 반환된다") {
+                result shouldBe response
+                verify { articleRepositoryPort.findArticleByQuery(lastArticleId = 0L, size = 10, categories = listOf(1L), sort = "createdAt", direction = "DESC", isQuestion = false, isTrending = true) }
+            }
+        }
     }
 })

--- a/hunmin-application/src/test/kotlin/com/application/article/ArticleServiceTest.kt
+++ b/hunmin-application/src/test/kotlin/com/application/article/ArticleServiceTest.kt
@@ -1,0 +1,275 @@
+package com.application.article
+
+import com.application.article.ArticleCommandFixture.Companion.삭제_글_생성_작성자id
+import com.application.article.ArticleCommandFixture.Companion.일반_글_생성
+import com.application.article.ArticleCommandFixture.Companion.일반_글_생성_신고처리
+import com.application.article.ArticleCommandFixture.Companion.일반_글_생성_작성자id
+import com.application.article.ArticleCommandFixture.Companion.일반_글_생성_커맨드
+import com.application.auth.AuthCommandFixture.Companion.인증_생성
+import com.application.auth.AuthCommandFixture.Companion.인증_생성_id
+import com.application.auth.AuthCommandFixture.Companion.인증_생성_어드민_id
+import com.application.category.CategoryCommandFixture.Companion.카테고리_생성
+import com.common.global.exceptions.base.CustomException
+import com.domain.article.exception.ArticleExceptionType.ARTICLE_NOT_FOUND
+import com.domain.article.exception.ArticleExceptionType.MISMATCHED_ARTICLE_WRITER
+import com.domain.article.port.`in`.command.ReportCommand
+import com.domain.article.port.out.ArticleRepositoryPort
+import com.domain.auth.exception.AuthExceptionType.AUTH_NOT_FOUND
+import com.domain.auth.port.out.AuthRepositoryPort
+import com.domain.category.exception.CategoryExceptionType.CATEGORY_NOT_FOUND
+import com.domain.category.port.out.CategoryRepositoryPort
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.assertDoesNotThrow
+
+class ArticleServiceTest : BehaviorSpec({
+
+    val articleRepositoryPort: ArticleRepositoryPort = mockk()
+    val authRepositoryPort: AuthRepositoryPort = mockk()
+    val categoryRepositoryPort: CategoryRepositoryPort = mockk()
+
+    val articleService = ArticleService(articleRepositoryPort, authRepositoryPort, categoryRepositoryPort)
+
+    Given("글 생성을 할 때") {
+
+        When("회원 정보가 없으면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns null
+
+            Then("예외를 발생시킨다") {
+                assertThatThrownBy {
+                    articleService.create(writerId = 1L, command = 일반_글_생성_커맨드())
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(AUTH_NOT_FOUND.message)
+            }
+        }
+
+        When("카테고리 정보가 없으면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(1L)
+            every { categoryRepositoryPort.findByIdOrNull(any()) } returns null
+
+            Then("예외를 발생시킨다") {
+                assertThatThrownBy {
+                    articleService.create(writerId = 1L, command = 일반_글_생성_커맨드())
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(CATEGORY_NOT_FOUND.message)
+            }
+        }
+
+        When("회원 정보와 카테고리 정보가 모두 있으면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성()
+            every { categoryRepositoryPort.findByIdOrNull(any()) } returns 카테고리_생성(createdAt = 1000)
+            every { articleRepositoryPort.save(any()) } returns 일반_글_생성()
+
+            Then("정상 생성된다") {
+                val article = articleService.create(writerId = 0L, command = 일반_글_생성_커맨드())
+
+                assertSoftly {
+                    article.writerId shouldBe 0L
+                    article.title shouldBe "글 제목"
+                    article.content shouldBe "글 내용"
+                    article.categoryId shouldBe 1L
+                    article.options.isVisible shouldBe true
+                    article.options.isQuestion shouldBe false
+                }
+            }
+        }
+    }
+
+    Given("글 삭제를 할 때") {
+
+        When("회원 정보가 없으면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns null
+
+            Then("예외를 발생시킨다") {
+                assertThatThrownBy {
+                    articleService.create(writerId = 0L, command = 일반_글_생성_커맨드())
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(AUTH_NOT_FOUND.message)
+            }
+        }
+
+        When("글 정보가 없으면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(0L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns null
+
+            Then("예외를 발생시킨다") {
+                assertThatThrownBy {
+                    articleService.delete(memberId = 0L, articleId = 1L)
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(ARTICLE_NOT_FOUND.message)
+            }
+        }
+
+        When("일반 유저이면서 작성자가 아니면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(2L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns 일반_글_생성()
+
+            Then("예외를 발생시킨다") {
+                assertThatThrownBy {
+                    articleService.delete(memberId = 2L, articleId = 0L)
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(MISMATCHED_ARTICLE_WRITER.message)
+            }
+        }
+
+        When("이미 삭제된 글이면 작성자더라도") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(2L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns 삭제_글_생성_작성자id(2L)
+
+            Then("예외를 발생시킨다") {
+                assertThatThrownBy {
+                    articleService.delete(memberId = 2L, articleId = 1L)
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(ARTICLE_NOT_FOUND.message)
+            }
+        }
+
+        When("이미 삭제된 글이면 어드민이더라도") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(2L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns 삭제_글_생성_작성자id(2L)
+
+            Then("예외를 발생시킨다") {
+                assertThatThrownBy {
+                    articleService.delete(memberId = 2L, articleId = 1L)
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(ARTICLE_NOT_FOUND.message)
+            }
+        }
+
+        When("일반 유저이면서 작성자고, 삭제되지 않았으면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(2L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns 일반_글_생성_작성자id(2L)
+
+            Then("삭제 처리 시 예외가 발생하지 않는다") {
+                assertDoesNotThrow { articleService.delete(memberId = 2L, articleId = 0L) }
+            }
+        }
+
+        When("어드민이면서 작성자가 아니고, 삭제되지 않았으면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(2L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns 일반_글_생성()
+
+            Then("삭제 처리 시 예외가 발생하지 않는다") {
+                assertDoesNotThrow { articleService.delete(memberId = 2L, articleId = 0L) }
+            }
+        }
+    }
+
+    Given("글 수정을 할 때") {
+        // TODO
+    }
+
+    Given("글 신고를 할 때") {
+
+        When("회원 정보가 없으면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns null
+
+            Then("예외를 발생시킨다") {
+                assertThatThrownBy {
+                    articleService.report(memberId = 0L, articleId = 0L, command = ReportCommand(reason = "신고 들어옴"))
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(AUTH_NOT_FOUND.message)
+            }
+        }
+
+        When("글 정보가 없으면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(0L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns null
+
+            Then("예외를 발생시킨다") {
+                assertThatThrownBy {
+                    articleService.report(memberId = 0L, articleId = 1L, command = ReportCommand(reason = "신고 들어옴"))
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(ARTICLE_NOT_FOUND.message)
+            }
+        }
+
+        When("어드민이 아니면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_id(2L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns 일반_글_생성()
+
+            Then("예외를 발생시킨다") {
+                assertThatThrownBy {
+                    articleService.report(memberId = 2L, articleId = 0L, command = ReportCommand(reason = "신고 들어옴"))
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(MISMATCHED_ARTICLE_WRITER.message)
+            }
+        }
+
+        When("이미 삭제된 글이면 어드민이더라도") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(2L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns 삭제_글_생성_작성자id(2L)
+
+            Then("예외를 발생시킨다") {
+                assertThatThrownBy {
+                    articleService.report(memberId = 2L, articleId = 0L, command = ReportCommand(reason = "신고 들어옴"))
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(ARTICLE_NOT_FOUND.message)
+            }
+        }
+
+        When("어드민이면서 작성자가 아니고, 삭제되지 않았으면") {
+            every { authRepositoryPort.findByIdOrNull(any()) } returns 인증_생성_어드민_id(2L)
+            every { articleRepositoryPort.findByIdOrNull(any()) } returns 일반_글_생성()
+            every { articleRepositoryPort.save(any()) } returns 일반_글_생성_신고처리()
+
+            Then("신고 처리 시 예외가 발생하지 않는다") {
+                assertDoesNotThrow { articleService.report(memberId = 2L, articleId = 0L, command = ReportCommand(reason = "신고 들어옴")) }
+            }
+        }
+    }
+
+    Given("글 단건 조회를 할 때") {
+
+        When("익명 / 일반 유저 / 작성자 / 어드민 상관없이, 글 정보가 아예 없으면") {
+            every { articleRepositoryPort.findArticleById(any()) } throws CustomException(ARTICLE_NOT_FOUND)
+
+            Then("예외가 발생한다") {
+                assertThatThrownBy {
+                    articleService.find(memberId = 1L, articleId = 1L)
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(ARTICLE_NOT_FOUND.message)
+            }
+        }
+
+        // TODO
+        When("익명일 때, 삭제된 상태면") {
+
+            Then("예외가 발생한다") {
+
+            }
+        }
+
+        // TODO
+        When("어드민이 아닐 때, 작성자 / 일반 유저더라도 삭제된 상태면") {
+
+            Then("예외가 발생한다") {
+
+            }
+        }
+
+        // TODO
+        When("익명일 때, 숨김 처리된 글이면") {
+
+            Then("예외가 발생한다") {
+
+            }
+        }
+
+        // TODO
+        When("일반 유저일 때, 숨김 처리된 글이면") {
+
+            Then("예외가 발생한다") {
+
+            }
+        }
+    }
+
+    Given("글 목록 조회를 할 때") {
+        // TODO
+    }
+})

--- a/hunmin-application/src/testFixtures/kotlin/com/application/article/ArticleCommandFixture.kt
+++ b/hunmin-application/src/testFixtures/kotlin/com/application/article/ArticleCommandFixture.kt
@@ -1,52 +1,11 @@
 package com.application.article
 
-import com.domain.article.Article
 import com.domain.article.port.`in`.command.CreateCommand
-import com.domain.article.vo.ArticleOptions
 
 class ArticleCommandFixture {
     companion object {
-        fun 일반_글_생성(): Article =
-            Article.createArticle(
-                title = "글 제목", content = "글 내용",
-                categoryId = 1L,
-                writerId = 0L,
-                isVisible = true,
-                isQuestion = false,
-            )
 
-        fun 일반_글_생성_신고처리(): Article {
-            val article = 일반_글_생성()
-            return article.updateReport(reportState = true)
-        }
-
-        fun 일반_글_생성_작성자id(writerId: Long): Article =
-            Article(
-                title = "글 제목",
-                content = "글 내용",
-                categoryId = 1L,
-                writerId = writerId,
-                options = ArticleOptions(),
-            )
-
-        fun 삭제_글_생성_작성자id(writerId: Long): Article =
-            Article(
-                title = "글 제목",
-                content = "글 내용",
-                categoryId = 1L,
-                writerId = writerId,
-                options = ArticleOptions(isDeleted = true),
-            )
-
-        fun 숨김_글_생성_작성자id(writerId: Long): Article =
-            Article(
-                title = "글 제목",
-                content = "글 내용",
-                categoryId = 1L,
-                writerId = writerId,
-                options = ArticleOptions(isVisible = false)
-            )
-        fun 일반_글_생성_커맨드(): CreateCommand =
+        fun 일반_글_생성_커맨드() =
             CreateCommand(
                 title = "글 제목", content = "글 내용", categoryId = 1L
             )

--- a/hunmin-application/src/testFixtures/kotlin/com/application/article/ArticleCommandFixture.kt
+++ b/hunmin-application/src/testFixtures/kotlin/com/application/article/ArticleCommandFixture.kt
@@ -1,0 +1,54 @@
+package com.application.article
+
+import com.domain.article.Article
+import com.domain.article.port.`in`.command.CreateCommand
+import com.domain.article.vo.ArticleOptions
+
+class ArticleCommandFixture {
+    companion object {
+        fun 일반_글_생성(): Article =
+            Article.createArticle(
+                title = "글 제목", content = "글 내용",
+                categoryId = 1L,
+                writerId = 0L,
+                isVisible = true,
+                isQuestion = false,
+            )
+
+        fun 일반_글_생성_신고처리(): Article {
+            val article = 일반_글_생성()
+            return article.updateReport(reportState = true)
+        }
+
+        fun 일반_글_생성_작성자id(writerId: Long): Article =
+            Article(
+                title = "글 제목",
+                content = "글 내용",
+                categoryId = 1L,
+                writerId = writerId,
+                options = ArticleOptions(),
+            )
+
+        fun 삭제_글_생성_작성자id(writerId: Long): Article =
+            Article(
+                title = "글 제목",
+                content = "글 내용",
+                categoryId = 1L,
+                writerId = writerId,
+                options = ArticleOptions(isDeleted = true),
+            )
+
+        fun 숨김_글_생성_작성자id(writerId: Long): Article =
+            Article(
+                title = "글 제목",
+                content = "글 내용",
+                categoryId = 1L,
+                writerId = writerId,
+                options = ArticleOptions(isVisible = false)
+            )
+        fun 일반_글_생성_커맨드(): CreateCommand =
+            CreateCommand(
+                title = "글 제목", content = "글 내용", categoryId = 1L
+            )
+    }
+}

--- a/hunmin-application/src/testFixtures/kotlin/com/application/auth/AuthCommandFixture.kt
+++ b/hunmin-application/src/testFixtures/kotlin/com/application/auth/AuthCommandFixture.kt
@@ -1,5 +1,6 @@
 package com.application.auth
 
+import com.common.global.auth.role.Role
 import com.domain.auth.Auth
 import com.domain.auth.port.`in`.command.SignInCommand
 import com.domain.auth.port.`in`.command.SignUpCommand
@@ -10,6 +11,21 @@ class AuthCommandFixture {
             Auth(
                 username = "username",
                 password = "password",
+            )
+
+        fun 인증_생성_id(id: Long): Auth =
+            Auth(
+                id = id,
+                username = "username",
+                password = "password",
+            )
+
+        fun 인증_생성_어드민_id(id: Long): Auth =
+            Auth(
+                id = id,
+                username = "admin",
+                password = "password",
+                role = Role.ADMIN,
             )
 
         fun 인증_생성_커맨드(): SignUpCommand =

--- a/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/ArticleApi.kt
+++ b/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/ArticleApi.kt
@@ -1,0 +1,265 @@
+package com.bootstrap.article.`in`
+
+import com.bootstrap.article.`in`.request.CreateArticleRequest
+import com.bootstrap.article.`in`.request.ReportArticleRequest
+import com.bootstrap.article.`in`.request.SearchArticlesRequest
+import com.bootstrap.article.`in`.request.UpdateArticleRequest
+import com.bootstrap.article.`in`.response.ArticleResponse
+import com.common.global.exceptions.base.ExceptionResponse
+import com.domain.article.dto.ArticleSimpleResponse
+import com.domain.article.dto.ArticlesSimpleResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+
+@Tag(name = "Article API")
+interface ArticleApi {
+
+    @Operation(summary = "지식 공유 글 생성")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "지식 공유 글 생성 성공",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ArticleResponse::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "값 누락으로 인한 생성 불가",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ExceptionResponse::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증 실패",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ExceptionResponse::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 부족으로 인한 생성 불가",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ExceptionResponse::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "카테고리 또는 회원 조회 실패",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ExceptionResponse::class)
+                )]
+            ),
+        ]
+    )
+    @PostMapping
+    fun create(
+        @Parameter(hidden = true)
+        memberId: Long,
+        @RequestBody request: CreateArticleRequest,
+    ): ResponseEntity<ArticleResponse>
+
+    @Operation(summary = "지식 공유 글 삭제")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                description = "지식 공유 글 삭제 성공"
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증 실패",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ExceptionResponse::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 부족 / 중복 삭제로 인한 삭제 불가",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ExceptionResponse::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "조회 실패",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ExceptionResponse::class)
+                )]
+            ),
+        ]
+    )
+    @DeleteMapping
+    fun delete(
+        @Parameter(hidden = true)
+        memberId: Long,
+        @Parameter(
+            description = "삭제할 글의 ID",
+            example = "1"
+        )
+        @PathVariable articleId: Long
+    ): ResponseEntity<Void>
+
+    @Operation(summary = "지식 공유 글 수정")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "지식 공유 글 수정 성공",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ArticleResponse::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증 실패",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ExceptionResponse::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한 부족으로 인한 수정 불가",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ExceptionResponse::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "카테고리 또는 회원 조회 실패",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ExceptionResponse::class)
+                )]
+            ),
+        ]
+    )
+    @PatchMapping("/{articleId}")
+    fun update(
+        @Parameter(hidden = true)
+        memberId: Long,
+        @Parameter(
+            description = "수정할 글의 ID",
+            example = "1"
+        )
+        @PathVariable articleId: Long,
+        @RequestBody request: UpdateArticleRequest,
+    ): ResponseEntity<ArticleResponse>
+
+    @Operation(summary = "지식 공유 글 신고")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                description = "지식 공유 글 신고 성공"
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "인증 실패",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ExceptionResponse::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "조회 실패",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ExceptionResponse::class)
+                )]
+            ),
+        ]
+    )
+    @PostMapping
+    fun report(
+        @Parameter(hidden = true)
+        memberId: Long,
+        @Parameter(
+            description = "신고할 글의 ID",
+            example = "1"
+        )
+        @PathVariable articleId: Long,
+        @RequestBody request: ReportArticleRequest,
+    ): ResponseEntity<Void>
+
+    @Operation(summary = "지식 공유 글 단건 조회")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "지식 공유 글 단건 조회 성공",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ArticleSimpleResponse::class)
+                )]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "조회 실패",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ExceptionResponse::class)
+                )]
+            ),
+        ]
+    )
+    @GetMapping
+    fun find(
+        @Parameter(hidden = true)
+        memberId: Long,
+        @Parameter(
+            description = "조회할 글의 ID",
+            example = "1"
+        )
+        @PathVariable articleId: Long,
+    ): ResponseEntity<ArticleSimpleResponse>
+
+    @Operation(summary = "지식 공유 글 목록 조회")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "지식 공유 글 목록 조회 성공",
+                content = [Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = ArticleSimpleResponse::class)
+                )]
+            ),
+        ]
+    )
+    @GetMapping
+    fun findArticlesWithNoOffsetPaging(
+        @Parameter(hidden = true)
+        memberId: Long,
+        @ParameterObject
+        @ModelAttribute request: SearchArticlesRequest,
+    ): ResponseEntity<ArticlesSimpleResponse>
+}

--- a/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/ArticleApi.kt
+++ b/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/ArticleApi.kt
@@ -113,7 +113,7 @@ interface ArticleApi {
             ),
         ]
     )
-    @DeleteMapping
+    @DeleteMapping("/{articleId}")
     fun delete(
         @Parameter(hidden = true)
         memberId: Long,
@@ -231,7 +231,7 @@ interface ArticleApi {
             ),
         ]
     )
-    @GetMapping
+    @GetMapping("/{articleId}")
     fun find(
         @Parameter(hidden = true)
         memberId: Long,

--- a/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/ArticleController.kt
+++ b/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/ArticleController.kt
@@ -7,7 +7,6 @@ import com.bootstrap.article.`in`.request.UpdateArticleRequest
 import com.bootstrap.article.`in`.response.ArticleResponse
 import com.common.global.auth.annotation.AuthMember
 import com.common.global.auth.role.Role
-import com.domain.article.dto.ArticlesSimpleResponse
 import com.domain.article.port.`in`.ArticleUseCase
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -84,6 +83,7 @@ class ArticleController(
                     .body(it)
             }
 
+    @GetMapping
     override fun findArticlesWithNoOffsetPaging(
         @AuthMember memberId: Long,
         @ModelAttribute request: SearchArticlesRequest

--- a/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/ArticleController.kt
+++ b/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/ArticleController.kt
@@ -77,7 +77,7 @@ class ArticleController(
         @AuthMember memberId: Long,
         articleId: Long,
     ) =
-        articleUseCase.find(memberId = memberId, articleId = articleId)
+        articleUseCase.findVisibleArticle(memberId = memberId, articleId = articleId)
             .let {
                 ResponseEntity.status(HttpStatus.OK)
                     .body(it)

--- a/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/ArticleController.kt
+++ b/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/ArticleController.kt
@@ -1,0 +1,96 @@
+package com.bootstrap.article.`in`
+
+import com.bootstrap.article.`in`.request.CreateArticleRequest
+import com.bootstrap.article.`in`.request.ReportArticleRequest
+import com.bootstrap.article.`in`.request.SearchArticlesRequest
+import com.bootstrap.article.`in`.request.UpdateArticleRequest
+import com.bootstrap.article.`in`.response.ArticleResponse
+import com.common.global.auth.annotation.AuthMember
+import com.common.global.auth.role.Role
+import com.domain.article.dto.ArticlesSimpleResponse
+import com.domain.article.port.`in`.ArticleUseCase
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/articles")
+@RestController
+class ArticleController(
+    private val articleUseCase: ArticleUseCase,
+) : ArticleApi {
+
+    @PostMapping
+    override fun create(
+        @AuthMember(requiredRole = Role.USER) memberId: Long,
+        @RequestBody request: CreateArticleRequest
+    ) =
+        articleUseCase.create(writerId = memberId, command = request.toCommand())
+            .let {
+                ResponseEntity.status(HttpStatus.CREATED)
+                    .body(ArticleResponse.from(it))
+            }
+
+    @DeleteMapping("/{articleId}")
+    override fun delete(
+        @AuthMember(requiredRole = Role.USER) memberId: Long,
+        @PathVariable articleId: Long
+    ) =
+        articleUseCase.delete(memberId = memberId, articleId = articleId)
+            .let {
+                ResponseEntity.status(HttpStatus.NO_CONTENT)
+                    .build<Void>()
+            }
+
+    @PatchMapping("/{articleId}")
+    override fun update(
+        @AuthMember(requiredRole = Role.USER) memberId: Long,
+        @PathVariable articleId: Long,
+        @RequestBody request: UpdateArticleRequest
+    ) =
+        articleUseCase.update(memberId = memberId, articleId = articleId, command = request.toCommand())
+            .let {
+                ResponseEntity.status(HttpStatus.OK)
+                    .body(ArticleResponse.from(it))
+            }
+
+    @PostMapping("/{articleId}")
+    override fun report(
+        @AuthMember(requiredRole = Role.USER) memberId: Long,
+        @PathVariable articleId: Long,
+        @RequestBody request: ReportArticleRequest,
+    ) =
+        articleUseCase.report(memberId = memberId, articleId = articleId, command = request.toCommand())
+            .let {
+                ResponseEntity.status(HttpStatus.NO_CONTENT)
+                    .build<Void>()
+            }
+
+    @GetMapping("/{articleId}")
+    override fun find(
+        @AuthMember memberId: Long,
+        articleId: Long,
+    ) =
+        articleUseCase.find(memberId = memberId, articleId = articleId)
+            .let {
+                ResponseEntity.status(HttpStatus.OK)
+                    .body(it)
+            }
+
+    override fun findArticlesWithNoOffsetPaging(
+        @AuthMember memberId: Long,
+        @ModelAttribute request: SearchArticlesRequest
+    ) =
+        articleUseCase.findArticlesWithNoOffsetPaging(memberId = memberId, query = request.toQuery())
+            .let {
+                ResponseEntity.status(HttpStatus.OK)
+                .body(it)
+            }
+}

--- a/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/ArticleController.kt
+++ b/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/ArticleController.kt
@@ -60,7 +60,7 @@ class ArticleController(
                     .body(ArticleResponse.from(it))
             }
 
-    @PostMapping("/{articleId}")
+    @PostMapping("/{articleId}/reports")
     override fun report(
         @AuthMember(requiredRole = Role.USER) memberId: Long,
         @PathVariable articleId: Long,

--- a/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/request/CreateArticleRequest.kt
+++ b/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/request/CreateArticleRequest.kt
@@ -1,0 +1,48 @@
+package com.bootstrap.article.`in`.request
+
+import com.domain.article.port.`in`.command.CreateCommand
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class CreateArticleRequest(
+
+    @Schema(
+        description = "카테고리 id",
+        example = "1"
+    )
+    val categoryId: Long,
+
+    @Schema(
+        description = "글 제목",
+        example = "자바스크립트 비동기 프로그래밍의 이해"
+    )
+    val title: String,
+
+    @Schema(
+        description = "글 내용",
+        example = "자바스크립트 비동기 프로그래밍은 현대 웹 개발에서 필수적인 개념입니다."
+    )
+    val content: String,
+
+    @Schema(
+        description = "노출 여부",
+        defaultValue = "true",
+        example = "true"
+    )
+    val isVisible: Boolean,
+
+    @Schema(
+        description = "질문 여부",
+        defaultValue = "false",
+        example = "false"
+    )
+    val isQuestion: Boolean,
+) {
+    fun toCommand() =
+        CreateCommand(
+            categoryId = categoryId,
+            title = title,
+            content = content,
+            isVisible = isVisible,
+            isQuestion = isQuestion
+        )
+}

--- a/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/request/ReportArticleRequest.kt
+++ b/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/request/ReportArticleRequest.kt
@@ -1,0 +1,18 @@
+package com.bootstrap.article.`in`.request
+
+import com.domain.article.port.`in`.command.ReportCommand
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ReportArticleRequest(
+
+    @Schema(
+        description = "신고 사유",
+        required = true
+    )
+    val reason: String,
+) {
+    fun toCommand() =
+        ReportCommand(
+            reason = reason,
+        )
+}

--- a/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/request/SearchArticlesRequest.kt
+++ b/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/request/SearchArticlesRequest.kt
@@ -1,0 +1,38 @@
+package com.bootstrap.article.`in`.request
+
+import com.domain.article.port.`in`.query.ListArticleFindQuery
+import io.swagger.v3.oas.annotations.Parameter
+
+data class SearchArticlesRequest(
+    @field:Parameter(description = "마지막으로 조회한 글 ID (첫 페이지 조회 시 생략)", required = false)
+    val lastArticleId: Long? = null,
+
+    @field:Parameter(description = "페이지 크기 (기본값: 10)", example = "10", required = false)
+    val size: Int = 10,
+
+    @field:Parameter(description = "조회할 글의 카테고리 ID (콤마로 구분)", example = "1,2", required = true)
+    val categories: String,
+
+    @field:Parameter(description = "정렬 기준 (createdAt / isTrending, 기본 createdAt)", example = "createdAt", required = false)
+    val sort: String = "createdAt",
+
+    @field:Parameter(description = "정렬 방향 (ASC / DESC, 기본 DESC)", example = "DESC", required = false)
+    val direction: String = "DESC",
+
+    @field:Parameter(description = "질문 글 조회 여부", example = "false", required = false)
+    val isQuestion: Boolean? = false,
+
+    @field:Parameter(description = "트렌딩 글 조회 여부", example = "false", required = false)
+    val isTrending: Boolean? = false,
+) {
+    fun toQuery(): ListArticleFindQuery =
+        ListArticleFindQuery(
+            lastArticleId = lastArticleId,
+            size = size,
+            categories = categories.split(",").map {it.toLong()},
+            sort = sort,
+            direction = direction,
+            isQuestion = isQuestion,
+            isTrending = isTrending,
+        )
+}

--- a/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/request/UpdateArticleRequest.kt
+++ b/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/request/UpdateArticleRequest.kt
@@ -8,26 +8,26 @@ data class UpdateArticleRequest(
         description = "카테고리 id",
         example = "1",
     )
-    val categoryId: Long?,
+    val categoryId: Long? = null,
 
     @Schema(
         description = "글 제목",
         example = "자바스크립트 비동기 프로그래밍의 이해"
     )
-    val title: String?,
+    val title: String? = null,
 
     @Schema(
         description = "글 내용",
         example = "자바스크립트 비동기 프로그래밍은 현대 웹 개발에서 필수적인 개념입니다."
     )
-    val content: String?,
+    val content: String? = null,
 
     @Schema(
         description = "노출 여부",
         defaultValue = "true",
         example = "true"
     )
-    val isVisible: Boolean?,
+    val isVisible: Boolean? = true,
 ) {
     fun toCommand() =
         UpdateCommand(

--- a/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/request/UpdateArticleRequest.kt
+++ b/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/request/UpdateArticleRequest.kt
@@ -1,0 +1,39 @@
+package com.bootstrap.article.`in`.request
+
+import com.domain.article.port.`in`.command.UpdateCommand
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class UpdateArticleRequest(
+    @Schema(
+        description = "카테고리 id",
+        example = "1",
+    )
+    val categoryId: Long?,
+
+    @Schema(
+        description = "글 제목",
+        example = "자바스크립트 비동기 프로그래밍의 이해"
+    )
+    val title: String?,
+
+    @Schema(
+        description = "글 내용",
+        example = "자바스크립트 비동기 프로그래밍은 현대 웹 개발에서 필수적인 개념입니다."
+    )
+    val content: String?,
+
+    @Schema(
+        description = "노출 여부",
+        defaultValue = "true",
+        example = "true"
+    )
+    val isVisible: Boolean?,
+) {
+    fun toCommand() =
+        UpdateCommand(
+            categoryId = categoryId,
+            title = title,
+            content = content,
+            isVisible = isVisible,
+        )
+}

--- a/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/response/ArticleResponse.kt
+++ b/hunmin-bootstrap/src/main/kotlin/com/bootstrap/article/in/response/ArticleResponse.kt
@@ -1,0 +1,90 @@
+package com.bootstrap.article.`in`.response
+
+import com.domain.article.Article
+import io.swagger.v3.oas.annotations.media.Schema
+
+class ArticleResponse(
+    @Schema(
+        description = "글 id",
+        example = "1"
+    )
+    val id: Long,
+
+    @Schema(
+        description = "글 제목",
+        example = "자바스크립트 비동기 프로그래밍의 이해"
+    )
+    val title: String,
+
+    @Schema(
+        description = "글 내용",
+        example = "자바스크립트 비동기 프로그래밍은 현대 웹 개발에서 필수적인 개념입니다."
+    )
+    val content: String,
+
+    @Schema(
+        description = "작성자 id",
+        example = "1"
+    )
+    val writerId: Long,
+
+    @Schema(
+        description = "카테고리 id",
+        example = "1"
+    )
+    val categoryId: Long,
+
+    @Schema(
+        description = "노출 여부",
+        defaultValue = "true",
+        example = "true"
+    )
+    val isVisible: Boolean,
+
+    @Schema(
+        description = "신고 여부",
+        defaultValue = "false",
+        example = "false"
+    )
+    val isReported: Boolean,
+
+    @Schema(
+        description = "트렌딩 여부",
+        defaultValue = "false",
+        example = "false"
+    )
+    val isTrending: Boolean,
+
+    @Schema(
+        description = "질문 여부",
+        defaultValue = "false",
+        example = "false"
+    )
+    val isQuestion: Boolean,
+
+    @Schema(
+        description = "삭제 여부",
+        defaultValue = "false",
+        example = "false"
+    )
+    val isDeleted: Boolean,
+
+    @Schema(
+        description = "글 생성 시각 (UTC)",
+        example = "1000"
+    )
+    val createdAt: Long,
+) {
+
+    companion object {
+        fun from(article: Article) =
+            ArticleResponse(
+                id = article.id,
+                title = article.title, content = article.content,
+                writerId = article.writerId, categoryId = article.categoryId,
+                isVisible = article.options.isVisible, isDeleted = article.options.isDeleted, isReported = article.options.isReported,
+                isTrending = article.options.isTrending, isQuestion = article.options.isQuestion,
+                createdAt = article.createdAt,
+            )
+    }
+}

--- a/hunmin-bootstrap/src/main/kotlin/com/bootstrap/global/config/AuthConfig.kt
+++ b/hunmin-bootstrap/src/main/kotlin/com/bootstrap/global/config/AuthConfig.kt
@@ -7,6 +7,7 @@ import com.common.global.auth.support.HttpMethod.GET
 import com.common.global.auth.support.HttpMethod.OPTIONS
 import com.common.global.auth.support.HttpMethod.PATCH
 import com.common.global.auth.support.HttpMethod.POST
+import com.common.global.auth.support.HttpMethod.DELETE
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.HandlerInterceptor
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
@@ -26,6 +27,7 @@ class AuthConfig(
         PathMatcherInterceptor(parseMemberIdFromTokenInterceptor)
             .excludePathPattern("/**", OPTIONS)
             .addPathPatterns("/category/**", POST, PATCH)
+            .addPathPatterns("/articles/**", GET, POST, PATCH, DELETE)
 
     private fun loginValidCheckerInterceptor(): HandlerInterceptor =
         PathMatcherInterceptor(loginValidCheckerInterceptor)
@@ -33,4 +35,6 @@ class AuthConfig(
             .excludePathPattern("/auth", POST, GET)
             .addPathPatterns("/auth/test", GET)
             .addPathPatterns("/category/**", POST, PATCH)
+            .addPathPatterns("/articles/**", POST, PATCH, DELETE)
+            .excludePathPattern("/articles/**", GET)
 }

--- a/hunmin-bootstrap/src/test/kotlin/com/bootstrap/article/in/ArticleControllerIntegrationTest.kt
+++ b/hunmin-bootstrap/src/test/kotlin/com/bootstrap/article/in/ArticleControllerIntegrationTest.kt
@@ -94,7 +94,7 @@ class ArticleControllerIntegrationTest(
             .header("Authorization", "Bearer $token")
             .contentType(ContentType.JSON)
             .body(request)
-            .post("/articles/1")
+            .post("/articles/1/reports")
             .then()
             .log()
             .all()

--- a/hunmin-bootstrap/src/test/kotlin/com/bootstrap/article/in/ArticleControllerIntegrationTest.kt
+++ b/hunmin-bootstrap/src/test/kotlin/com/bootstrap/article/in/ArticleControllerIntegrationTest.kt
@@ -1,0 +1,181 @@
+package com.bootstrap.article.`in`
+
+import com.bootstrap.article.`in`.request.CreateArticleRequest
+import com.bootstrap.article.`in`.request.ReportArticleRequest
+import com.bootstrap.article.`in`.request.UpdateArticleRequest
+import com.bootstrap.helper.IntegrationTest
+import com.common.global.auth.role.Role
+import com.common.global.auth.token.TokenProvider
+import com.domain.article.Article
+import com.domain.article.port.out.ArticleRepositoryPort
+import com.domain.auth.Auth
+import com.domain.auth.port.out.AuthPasswordEncryptor
+import com.domain.auth.port.out.AuthRepositoryPort
+import com.domain.category.Category
+import com.domain.category.port.out.CategoryRepositoryPort
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@IntegrationTest
+class ArticleControllerIntegrationTest(
+    @Autowired private val authRepositoryPort: AuthRepositoryPort,
+    @Autowired private val authPasswordEncryptor: AuthPasswordEncryptor,
+    @Autowired private val categoryRepositoryPort: CategoryRepositoryPort,
+    @Autowired private val articleRepositoryPort: ArticleRepositoryPort,
+    @Autowired private val tokenProvider: TokenProvider
+) {
+    val token = tokenProvider.create(id = 1L, role = Role.ADMIN)
+
+    @Test
+    fun `지식 공유 글을 생성한다`() {
+        // given
+        authRepositoryPort.save(Auth.signUpWithEncryption(username = "admin", password = "password", authPasswordEncryptor = authPasswordEncryptor, role = Role.ADMIN))
+        categoryRepositoryPort.save(Category(title = "카테고리", isVisible = true))
+        val request = CreateArticleRequest(categoryId = 1L, title = "제목", content = "본문", isVisible = true, isQuestion = false)
+
+        // when
+        val response = RestAssured.given()
+            .log()
+            .all()
+            .`when`()
+            .header("Authorization", "Bearer $token")
+            .contentType(ContentType.JSON)
+            .body(request)
+            .post("/articles")
+            .then()
+            .log()
+            .all()
+            .extract()
+
+        // then
+        assertEquals(response.statusCode(), HttpStatus.CREATED.value())
+    }
+
+    @Test
+    fun `지식 공유 글을 단건 조회한다`() {
+        // given
+        authRepositoryPort.save(Auth.signUpWithEncryption(username = "admin", password = "password", authPasswordEncryptor = authPasswordEncryptor, role = Role.ADMIN))
+        categoryRepositoryPort.save(Category(title = "카테고리", isVisible = true))
+        articleRepositoryPort.save(Article.createArticle(title = "제목", content = "글", categoryId = 1L, writerId = 1L, isVisible = true, isQuestion = false))
+
+        // when
+        val response = RestAssured.given()
+            .log()
+            .all()
+            .`when`()
+            .header("Authorization", "Bearer $token")
+            .get("/articles/1")
+            .then()
+            .log()
+            .all()
+            .extract()
+
+        // then
+        assertEquals(response.statusCode(), HttpStatus.OK.value())
+    }
+
+    @Test
+    fun `지식 공유 글을 신고한다`() {
+        // given
+        authRepositoryPort.save(Auth.signUpWithEncryption(username = "admin", password = "password", authPasswordEncryptor = authPasswordEncryptor, role = Role.ADMIN))
+        categoryRepositoryPort.save(Category(title = "카테고리", isVisible = true))
+        articleRepositoryPort.save(Article.createArticle(title = "제목", content = "글", categoryId = 1L, writerId = 1L, isVisible = true, isQuestion = false))
+        val request = ReportArticleRequest(reason = "글 신고")
+
+        // when
+        val response = RestAssured.given()
+            .log()
+            .all()
+            .`when`()
+            .header("Authorization", "Bearer $token")
+            .contentType(ContentType.JSON)
+            .body(request)
+            .post("/articles/1")
+            .then()
+            .log()
+            .all()
+            .extract()
+
+        // then
+        assertEquals(response.statusCode(), HttpStatus.NO_CONTENT.value())
+    }
+
+    @Test
+    fun `지식 공유 글을 삭제한다`() {
+        // given
+        authRepositoryPort.save(Auth.signUpWithEncryption(username = "admin", password = "password", authPasswordEncryptor = authPasswordEncryptor, role = Role.ADMIN))
+        categoryRepositoryPort.save(Category(title = "카테고리", isVisible = true))
+        articleRepositoryPort.save(Article.createArticle(title = "제목", content = "글", categoryId = 1L, writerId = 1L, isVisible = true, isQuestion = false))
+
+        // when
+        val response = RestAssured.given()
+            .log()
+            .all()
+            .`when`()
+            .header("Authorization", "Bearer $token")
+            .delete("/articles/1")
+            .then()
+            .log()
+            .all()
+            .extract()
+
+        // then
+        assertEquals(response.statusCode(), HttpStatus.NO_CONTENT.value())
+    }
+
+    @Test
+    fun `지식 공유 글을 수정한다`() {
+        // given
+        authRepositoryPort.save(Auth.signUpWithEncryption(username = "admin", password = "password", authPasswordEncryptor = authPasswordEncryptor, role = Role.ADMIN))
+        categoryRepositoryPort.save(Category(title = "카테고리", isVisible = true))
+        articleRepositoryPort.save(Article.createArticle(title = "제목", content = "글", categoryId = 1L, writerId = 1L, isVisible = true, isQuestion = false))
+        val request = UpdateArticleRequest(title = "제목 수정")
+
+        // when
+        val response = RestAssured.given()
+            .log()
+            .all()
+            .`when`()
+            .header("Authorization", "Bearer $token")
+            .contentType(ContentType.JSON)
+            .body(request)
+            .patch("/articles/1")
+            .then()
+            .log()
+            .all()
+            .extract()
+
+        // then
+        assertEquals(response.statusCode(), HttpStatus.OK.value())
+    }
+
+    @Test
+    fun `지식 공유 글을 no-offset 페이징 조회를 한다`() {
+        // given
+        authRepositoryPort.save(Auth.signUpWithEncryption(username = "admin", password = "password", authPasswordEncryptor = authPasswordEncryptor, role = Role.ADMIN))
+        categoryRepositoryPort.save(Category(title = "카테고리 1", isVisible = true))
+        categoryRepositoryPort.save(Category(title = "카테고리 2", isVisible = true))
+        articleRepositoryPort.save(Article.createArticle(title = "제목 1", content = "글 1", categoryId = 1L, writerId = 1L, isVisible = true, isQuestion = false))
+        articleRepositoryPort.save(Article.createArticle(title = "제목 2", content = "글 2", categoryId = 1L, writerId = 1L, isVisible = true, isQuestion = false))
+        articleRepositoryPort.save(Article.createArticle(title = "제목 3", content = "글 3", categoryId = 2L, writerId = 1L, isVisible = true, isQuestion = false))
+
+        // when
+        val response = RestAssured.given()
+            .log()
+            .all()
+            .`when`()
+            .queryParam("categories", "1")
+            .get("/articles")
+            .then()
+            .log()
+            .all()
+            .extract()
+
+        // then
+        assertEquals(response.statusCode(), HttpStatus.OK.value())
+    }
+}

--- a/hunmin-common/src/main/kotlin/com/common/global/auth/annotation/AuthMember.kt
+++ b/hunmin-common/src/main/kotlin/com/common/global/auth/annotation/AuthMember.kt
@@ -9,5 +9,5 @@ import com.common.global.auth.role.Role
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class AuthMember(
-    val requiredRole: Role = Role.USER
+    val requiredRole: Role = Role.ANONYMOUS
 )

--- a/hunmin-common/src/main/kotlin/com/common/global/auth/resolver/AuthMemberArgumentResolver.kt
+++ b/hunmin-common/src/main/kotlin/com/common/global/auth/resolver/AuthMemberArgumentResolver.kt
@@ -37,8 +37,4 @@ class AuthMemberArgumentResolver(
 
         return authenticationContext.getPrincipal()
     }
-
-    companion object {
-        private const val ANONYMOUS_AUTH_ID: Long = -1L
-    }
 }

--- a/hunmin-common/src/main/kotlin/com/common/global/auth/role/Role.kt
+++ b/hunmin-common/src/main/kotlin/com/common/global/auth/role/Role.kt
@@ -10,6 +10,7 @@ enum class Role(
     private val priority: Int
 ) {
 
+    ANONYMOUS(-1),
     USER(1),
     ADMIN(2);
 

--- a/hunmin-common/src/main/kotlin/com/common/global/auth/support/AuthenticationContext.kt
+++ b/hunmin-common/src/main/kotlin/com/common/global/auth/support/AuthenticationContext.kt
@@ -9,8 +9,8 @@ import org.springframework.web.context.annotation.RequestScope
 @RequestScope
 @Component
 class AuthenticationContext(
-    private var memberId: Long? = null,
-    private var role: Role? = null,
+    private var memberId: Long? = ANONYMOUS_MEMBER,
+    private var role: Role? = Role.ANONYMOUS,
 ) {
     fun setAuthentication(memberId: Long, role: Role) {
         this.memberId = memberId
@@ -22,11 +22,11 @@ class AuthenticationContext(
             ?: throw CustomException(AuthExceptionType.AUTH_NOT_FOUND)
 
     fun getRole(): Role =
-        role ?: throw CustomException(AuthExceptionType.ROLE_NOT_FOUND)
+        role ?: Role.ANONYMOUS
 
     fun setAnonymous() {
         this.memberId = ANONYMOUS_MEMBER
-        this.role = null
+        this.role = Role.ANONYMOUS
     }
 
     companion object {

--- a/hunmin-common/src/main/kotlin/com/common/global/auth/token/JwtTokenProvider.kt
+++ b/hunmin-common/src/main/kotlin/com/common/global/auth/token/JwtTokenProvider.kt
@@ -86,12 +86,16 @@ class JwtTokenProvider(
             .build()
             .parseSignedClaims(token)
             .body["role"] as? String
-            ?: throw CustomException(AuthExceptionType.ROLE_NOT_FOUND)
+            ?: ANONYMOUS_ROLE
 
         return try {
             Role.valueOf(role.uppercase())
         } catch (exception: IllegalArgumentException) {
             throw CustomException(AuthExceptionType.ROLE_NOT_FOUND)
         }
+    }
+
+    companion object {
+        private val ANONYMOUS_ROLE = "anonymous"
     }
 }

--- a/hunmin-domain/src/main/kotlin/com/domain/article/Article.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/Article.kt
@@ -4,7 +4,7 @@ import com.domain.aggregate.AggregateRoot
 import com.domain.article.event.ArticleEvent
 import com.domain.article.vo.ArticleOptions
 
-class Article private constructor(
+class Article(
     override val id: Long = 0,
     val title: String,
     val content: String,

--- a/hunmin-domain/src/main/kotlin/com/domain/article/Article.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/Article.kt
@@ -2,18 +2,54 @@ package com.domain.article
 
 import com.domain.aggregate.AggregateRoot
 import com.domain.article.event.ArticleEvent
+import com.domain.article.vo.ArticleOptions
 
 class Article(
     override val id: Long = 0,
     val title: String,
     val content: String,
-    val categoryId: Long,
     val writerId: Long,
-    val isVisible: Boolean = true,
-    val isBlamed: Boolean = false,
-    val isQuestion: Boolean = false,
+    val categoryId: Long,
+    val options: ArticleOptions,
     val createdAt: Long = 0,
 ) : AggregateRoot<ArticleEvent, Long>() {
+
+    fun delete(): Article =
+        Article(
+            id = id,
+            title = title,
+            content = content,
+            writerId = writerId,
+            categoryId = categoryId,
+            options = options.delete(),
+            createdAt = createdAt
+        )
+
+    fun update(categoryId: Long?, title: String?, content: String?, isVisible: Boolean?): Article =
+        Article(
+            id = id,
+            title = title ?: this.title,
+            content = content ?: this.content,
+            writerId = this.writerId,
+            categoryId = categoryId ?: this.categoryId,
+            options = this.options.update(isVisible = isVisible),
+            createdAt = this.createdAt,
+        )
+
+    fun isDeleted() =
+        this.options.isDeletedState()
+
+    fun updateReport(reportState: Boolean): Article {
+        return Article(
+            id = id,
+            title = title,
+            content = content,
+            writerId = this.writerId,
+            categoryId = categoryId,
+            options = this.options.updateReport(reportState),
+            createdAt = this.createdAt,
+        )
+    }
 
     companion object {
         fun createArticle(
@@ -21,13 +57,11 @@ class Article(
             content: String,
             categoryId: Long,
             writerId: Long,
-        ) = Article(title = title, content = content, categoryId = categoryId, writerId = writerId)
-
-        fun createQuestionArticle(
-            title: String,
-            content: String,
-            categoryId: Long,
-            writerId: Long,
-        ) = Article(title = title, content = content, categoryId = categoryId, writerId = writerId, isQuestion = true)
+            isVisible: Boolean,
+            isQuestion: Boolean,
+        ) = Article(
+            title = title, content = content, categoryId = categoryId, writerId = writerId,
+            options = ArticleOptions.createOptions(isVisible = isVisible, isQuestion = isQuestion)
+        )
     }
 }

--- a/hunmin-domain/src/main/kotlin/com/domain/article/Article.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/Article.kt
@@ -1,0 +1,33 @@
+package com.domain.article
+
+import com.domain.aggregate.AggregateRoot
+import com.domain.article.event.ArticleEvent
+
+class Article(
+    override val id: Long = 0,
+    val title: String,
+    val content: String,
+    val categoryId: Long,
+    val writerId: Long,
+    val isVisible: Boolean = true,
+    val isBlamed: Boolean = false,
+    val isQuestion: Boolean = false,
+    val createdAt: Long = 0,
+) : AggregateRoot<ArticleEvent, Long>() {
+
+    companion object {
+        fun createArticle(
+            title: String,
+            content: String,
+            categoryId: Long,
+            writerId: Long,
+        ) = Article(title = title, content = content, categoryId = categoryId, writerId = writerId)
+
+        fun createQuestionArticle(
+            title: String,
+            content: String,
+            categoryId: Long,
+            writerId: Long,
+        ) = Article(title = title, content = content, categoryId = categoryId, writerId = writerId, isQuestion = true)
+    }
+}

--- a/hunmin-domain/src/main/kotlin/com/domain/article/Article.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/Article.kt
@@ -14,18 +14,16 @@ class Article(
     val createdAt: Long = 0,
 ) : AggregateRoot<ArticleEvent, Long>() {
 
-    fun delete(): Article =
+    fun delete() =
         Article(
             id = id,
-            title = title,
-            content = content,
-            writerId = writerId,
-            categoryId = categoryId,
+            title = title, content = content,
+            writerId = writerId, categoryId = categoryId,
             options = options.delete(),
             createdAt = createdAt
         )
 
-    fun update(categoryId: Long? = null, title: String? = null, content: String? = null, isVisible: Boolean? = null): Article =
+    fun update(categoryId: Long? = null, title: String? = null, content: String? = null, isVisible: Boolean? = null) =
         Article(
             id = this.id,
             title = title ?: this.title,
@@ -33,35 +31,33 @@ class Article(
             writerId = this.writerId,
             categoryId = categoryId ?: this.categoryId,
             options = this.options.updateVisible(isVisible = isVisible),
-            createdAt = this.createdAt,
+            createdAt = this.createdAt
         )
 
     fun isDeleted() =
         this.options.isDeletedState()
 
-    fun updateReport(reportState: Boolean): Article {
-        return Article(
+    fun updateReport(reportState: Boolean) =
+        Article(
             id = id,
             title = title,
             content = content,
             writerId = this.writerId,
             categoryId = categoryId,
             options = this.options.updateReport(reportState),
-            createdAt = this.createdAt,
+            createdAt = this.createdAt
         )
-    }
 
     companion object {
         fun createArticle(
-            title: String,
-            content: String,
-            categoryId: Long,
-            writerId: Long,
-            isVisible: Boolean,
-            isQuestion: Boolean,
-        ) = Article(
-            title = title, content = content, categoryId = categoryId, writerId = writerId,
-            options = ArticleOptions.createOptions(isVisible = isVisible, isQuestion = isQuestion)
-        )
+            title: String, content: String,
+            categoryId: Long, writerId: Long,
+            isVisible: Boolean, isQuestion: Boolean,
+        ) =
+            Article(
+                title = title, content = content,
+                categoryId = categoryId, writerId = writerId,
+                options = ArticleOptions.createOptions(isVisible = isVisible, isQuestion = isQuestion)
+            )
     }
 }

--- a/hunmin-domain/src/main/kotlin/com/domain/article/Article.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/Article.kt
@@ -4,7 +4,7 @@ import com.domain.aggregate.AggregateRoot
 import com.domain.article.event.ArticleEvent
 import com.domain.article.vo.ArticleOptions
 
-class Article(
+class Article private constructor(
     override val id: Long = 0,
     val title: String,
     val content: String,
@@ -52,12 +52,12 @@ class Article(
         fun createArticle(
             title: String, content: String,
             categoryId: Long, writerId: Long,
-            isVisible: Boolean, isQuestion: Boolean,
+            isVisible: Boolean = true, isQuestion: Boolean = false, isDeleted: Boolean = false,
         ) =
             Article(
                 title = title, content = content,
                 categoryId = categoryId, writerId = writerId,
-                options = ArticleOptions.createOptions(isVisible = isVisible, isQuestion = isQuestion)
+                options = ArticleOptions.createOptions(isVisible = isVisible, isQuestion = isQuestion, isDeleted = isDeleted)
             )
     }
 }

--- a/hunmin-domain/src/main/kotlin/com/domain/article/Article.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/Article.kt
@@ -25,14 +25,14 @@ class Article(
             createdAt = createdAt
         )
 
-    fun update(categoryId: Long?, title: String?, content: String?, isVisible: Boolean?): Article =
+    fun update(categoryId: Long? = null, title: String? = null, content: String? = null, isVisible: Boolean? = null): Article =
         Article(
-            id = id,
+            id = this.id,
             title = title ?: this.title,
             content = content ?: this.content,
             writerId = this.writerId,
             categoryId = categoryId ?: this.categoryId,
-            options = this.options.update(isVisible = isVisible),
+            options = this.options.updateVisible(isVisible = isVisible),
             createdAt = this.createdAt,
         )
 

--- a/hunmin-domain/src/main/kotlin/com/domain/article/Article.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/Article.kt
@@ -21,7 +21,9 @@ class Article private constructor(
             writerId = writerId, categoryId = categoryId,
             options = options.delete(),
             createdAt = createdAt
-        )
+        ).apply {
+            ArticleEvent.deleted(this)
+        }
 
     fun update(categoryId: Long? = null, title: String? = null, content: String? = null, isVisible: Boolean? = null) =
         Article(
@@ -32,7 +34,9 @@ class Article private constructor(
             categoryId = categoryId ?: this.categoryId,
             options = this.options.updateVisible(isVisible = isVisible),
             createdAt = this.createdAt
-        )
+        ).apply {
+            ArticleEvent.updated(this)
+        }
 
     fun isDeleted() =
         this.options.isDeletedState()
@@ -46,7 +50,9 @@ class Article private constructor(
             categoryId = categoryId,
             options = this.options.updateReport(reportState),
             createdAt = this.createdAt
-        )
+        ).apply {
+            ArticleEvent.updated(this)
+        }
 
     companion object {
         fun createArticle(
@@ -58,6 +64,8 @@ class Article private constructor(
                 title = title, content = content,
                 categoryId = categoryId, writerId = writerId,
                 options = ArticleOptions.createOptions(isVisible = isVisible, isQuestion = isQuestion, isDeleted = isDeleted)
-            )
+            ).apply {
+                ArticleEvent.created(this)
+            }
     }
 }

--- a/hunmin-domain/src/main/kotlin/com/domain/article/dto/ArticleSimpleResponse.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/dto/ArticleSimpleResponse.kt
@@ -1,0 +1,30 @@
+package com.domain.article.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.Instant
+
+data class ArticlesSimpleResponse(
+    val articles: List<ArticleSimpleResponse>,
+)
+
+data class ArticleSimpleResponse(
+    val articleId: Long,
+    val title: String,
+    val content: String,
+    val writerId: Long,
+    val writerName: String,
+    val categoryId: Long,
+    val categoryName: String,
+    val isVisible: Boolean,
+    val isReported: Boolean,
+    val isTrending: Boolean,
+    val isQuestion: Boolean,
+    val isDeleted: Boolean,
+    @JsonIgnore
+    val createdAt: Instant,
+) {
+    @get:JsonProperty("createdAt")
+    val createdAtMillis: Long
+        get() = createdAt.toEpochMilli()
+}

--- a/hunmin-domain/src/main/kotlin/com/domain/article/event/ArticleEvent.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/event/ArticleEvent.kt
@@ -1,5 +1,52 @@
 package com.domain.article.event
 
 import com.domain.aggregate.DomainEvent
+import com.domain.article.Article
+import java.time.Instant
 
-sealed class ArticleEvent : DomainEvent
+sealed class ArticleEvent : DomainEvent {
+
+    companion object {
+        fun created(article: Article) {
+            article.addEvent(
+                ArticleCreatedEvent(
+                    articleId = article.id,
+                    createdDateTime = Instant.now().toEpochMilli()
+                )
+            )
+        }
+
+        fun updated(article: Article) {
+            article.addEvent(
+                ArticleUpdatedEvent(
+                    articleId = article.id,
+                    updatedDateTime = Instant.now().toEpochMilli(),
+                )
+            )
+        }
+
+        fun deleted(article: Article) {
+            article.addEvent(
+                ArticleDeletedEvent(
+                    articleId = article.id,
+                    deletedDateTime = Instant.now().toEpochMilli(),
+                )
+            )
+        }
+    }
+}
+
+class ArticleCreatedEvent(
+    val articleId: Long,
+    val createdDateTime: Long,
+): ArticleEvent()
+
+class ArticleUpdatedEvent(
+    val articleId: Long,
+    val updatedDateTime: Long,
+): ArticleEvent()
+
+class ArticleDeletedEvent(
+    val articleId: Long,
+    val deletedDateTime: Long,
+): ArticleEvent()

--- a/hunmin-domain/src/main/kotlin/com/domain/article/event/ArticleEvent.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/event/ArticleEvent.kt
@@ -1,0 +1,5 @@
+package com.domain.article.event
+
+import com.domain.aggregate.DomainEvent
+
+sealed class ArticleEvent : DomainEvent

--- a/hunmin-domain/src/main/kotlin/com/domain/article/exception/ArticleExceptionType.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/exception/ArticleExceptionType.kt
@@ -1,0 +1,28 @@
+package com.domain.article.exception
+
+import com.common.global.exceptions.base.CustomExceptionType
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+
+enum class ArticleExceptionType : CustomExceptionType {
+    ARTICLE_NOT_FOUND {
+        override val subject: String = "ARTICLE_EXCEPTION"
+        override val errorCode: String = this.name
+        override val message: String = "글을 찾을 수 없습니다."
+        override val httpStatusCode: HttpStatusCode = HttpStatus.NOT_FOUND
+    },
+
+    MISMATCHED_ARTICLE_WRITER {
+        override val subject: String = "ARTICLE_EXCEPTION"
+        override val errorCode: String = this.name
+        override val message: String = "글의 작성자가 아닙니다."
+        override val httpStatusCode: HttpStatusCode = HttpStatus.FORBIDDEN
+    },
+
+    ALREADY_DELETED_ARTICLE {
+        override val subject: String = "ARTICLE_EXCEPTION"
+        override val errorCode: String = this.name
+        override val message: String = "이미 삭제된 글입니다."
+        override val httpStatusCode: HttpStatusCode = HttpStatus.BAD_REQUEST
+    }
+}

--- a/hunmin-domain/src/main/kotlin/com/domain/article/port/in/ArticleUseCase.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/port/in/ArticleUseCase.kt
@@ -1,0 +1,18 @@
+package com.domain.article.port.`in`
+
+import com.domain.article.Article
+import com.domain.article.dto.ArticleSimpleResponse
+import com.domain.article.dto.ArticlesSimpleResponse
+import com.domain.article.port.`in`.command.CreateCommand
+import com.domain.article.port.`in`.command.ReportCommand
+import com.domain.article.port.`in`.command.UpdateCommand
+import com.domain.article.port.`in`.query.ListArticleFindQuery
+
+interface ArticleUseCase {
+    fun create(writerId: Long, command: CreateCommand): Article
+    fun delete(memberId: Long, articleId: Long): Unit
+    fun update(memberId: Long, articleId: Long, command: UpdateCommand): Article
+    fun report(memberId: Long, articleId: Long, command: ReportCommand): Unit
+    fun find(memberId: Long, articleId: Long): ArticleSimpleResponse
+    fun findArticlesWithNoOffsetPaging(memberId: Long, query: ListArticleFindQuery): ArticlesSimpleResponse
+}

--- a/hunmin-domain/src/main/kotlin/com/domain/article/port/in/ArticleUseCase.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/port/in/ArticleUseCase.kt
@@ -13,6 +13,6 @@ interface ArticleUseCase {
     fun delete(memberId: Long, articleId: Long): Unit
     fun update(memberId: Long, articleId: Long, command: UpdateCommand): Article
     fun report(memberId: Long, articleId: Long, command: ReportCommand): Unit
-    fun find(memberId: Long, articleId: Long): ArticleSimpleResponse
+    fun findVisibleArticle(memberId: Long, articleId: Long): ArticleSimpleResponse
     fun findArticlesWithNoOffsetPaging(memberId: Long, query: ListArticleFindQuery): ArticlesSimpleResponse
 }

--- a/hunmin-domain/src/main/kotlin/com/domain/article/port/in/command/CreateCommand.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/port/in/command/CreateCommand.kt
@@ -1,0 +1,9 @@
+package com.domain.article.port.`in`.command
+
+data class CreateCommand(
+    val categoryId: Long,
+    val title: String,
+    val content: String,
+    val isVisible: Boolean = true,
+    val isQuestion: Boolean = false,
+)

--- a/hunmin-domain/src/main/kotlin/com/domain/article/port/in/command/ReportCommand.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/port/in/command/ReportCommand.kt
@@ -1,0 +1,6 @@
+package com.domain.article.port.`in`.command
+
+data class ReportCommand(
+    val reason: String,
+    val reportState: Boolean = true,
+)

--- a/hunmin-domain/src/main/kotlin/com/domain/article/port/in/command/UpdateCommand.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/port/in/command/UpdateCommand.kt
@@ -1,0 +1,8 @@
+package com.domain.article.port.`in`.command
+
+data class UpdateCommand(
+    val categoryId: Long?,
+    val title: String?,
+    val content: String?,
+    val isVisible: Boolean?,
+)

--- a/hunmin-domain/src/main/kotlin/com/domain/article/port/in/command/UpdateCommand.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/port/in/command/UpdateCommand.kt
@@ -1,8 +1,8 @@
 package com.domain.article.port.`in`.command
 
 data class UpdateCommand(
-    val categoryId: Long?,
-    val title: String?,
-    val content: String?,
-    val isVisible: Boolean?,
+    val categoryId: Long? = null,
+    val title: String? = null,
+    val content: String? = null,
+    val isVisible: Boolean? = null,
 )

--- a/hunmin-domain/src/main/kotlin/com/domain/article/port/in/query/ListArticleFindQuery.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/port/in/query/ListArticleFindQuery.kt
@@ -1,0 +1,11 @@
+package com.domain.article.port.`in`.query
+
+data class ListArticleFindQuery(
+    val lastArticleId: Long?,
+    val size: Int,
+    val categories: List<Long>,
+    val sort: String,
+    val direction: String,
+    val isQuestion: Boolean?,
+    val isTrending: Boolean?,
+)

--- a/hunmin-domain/src/main/kotlin/com/domain/article/port/out/ArticleRepositoryPort.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/port/out/ArticleRepositoryPort.kt
@@ -1,0 +1,6 @@
+package com.domain.article.port.out
+
+import com.domain.aggregate.AggregateRepository
+import com.domain.article.Article
+
+interface ArticleRepositoryPort : AggregateRepository<Article, Long>

--- a/hunmin-domain/src/main/kotlin/com/domain/article/port/out/ArticleRepositoryPort.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/port/out/ArticleRepositoryPort.kt
@@ -2,5 +2,11 @@ package com.domain.article.port.out
 
 import com.domain.aggregate.AggregateRepository
 import com.domain.article.Article
+import com.domain.article.dto.ArticleSimpleResponse
+import com.domain.article.dto.ArticlesSimpleResponse
 
-interface ArticleRepositoryPort : AggregateRepository<Article, Long>
+interface ArticleRepositoryPort : AggregateRepository<Article, Long> {
+
+    fun findArticleById(articleId: Long): ArticleSimpleResponse
+    fun findArticleByQuery(lastArticleId: Long?, size: Int, categories: List<Long>, sort: String, direction: String, isQuestion: Boolean?, isTrending: Boolean?): ArticlesSimpleResponse
+}

--- a/hunmin-domain/src/main/kotlin/com/domain/article/vo/ArticleOptions.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/vo/ArticleOptions.kt
@@ -19,14 +19,11 @@ data class ArticleOptions(
         return copy(isDeleted = true)
     }
 
-    fun update(isVisible: Boolean?) =
+    fun updateVisible(isVisible: Boolean? = null) =
         this.copy(isVisible = isVisible ?: this.isVisible)
 
     fun isDeletedState() =
         this.isDeleted
-
-    fun isReportedState() =
-        this.isReported
 
     companion object {
         fun createOptions(isVisible: Boolean, isQuestion: Boolean): ArticleOptions = ArticleOptions(

--- a/hunmin-domain/src/main/kotlin/com/domain/article/vo/ArticleOptions.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/vo/ArticleOptions.kt
@@ -1,0 +1,40 @@
+package com.domain.article.vo
+
+import com.common.global.exceptions.base.CustomException
+import com.domain.article.exception.ArticleExceptionType
+
+data class ArticleOptions(
+    val isVisible: Boolean = true,
+    val isReported: Boolean = false,
+    val isTrending: Boolean = false,
+    val isQuestion: Boolean = false,
+    val isDeleted: Boolean = false,
+) {
+    fun updateReport(reportState: Boolean) = copy(isReported = reportState)
+
+    fun delete(): ArticleOptions {
+        if (this.isDeleted) {
+            throw CustomException(ArticleExceptionType.ALREADY_DELETED_ARTICLE)
+        }
+        return copy(isDeleted = true)
+    }
+
+    fun update(isVisible: Boolean?) =
+        this.copy(isVisible = isVisible ?: this.isVisible)
+
+    fun isDeletedState() =
+        this.isDeleted
+
+    fun isReportedState() =
+        this.isReported
+
+    companion object {
+        fun createOptions(isVisible: Boolean, isQuestion: Boolean): ArticleOptions = ArticleOptions(
+            isVisible = isVisible,
+            isReported = false,
+            isTrending = false,
+            isQuestion = isQuestion,
+            isDeleted = false,
+        )
+    }
+}

--- a/hunmin-domain/src/main/kotlin/com/domain/article/vo/ArticleOptions.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/article/vo/ArticleOptions.kt
@@ -26,12 +26,12 @@ data class ArticleOptions(
         this.isDeleted
 
     companion object {
-        fun createOptions(isVisible: Boolean, isQuestion: Boolean): ArticleOptions = ArticleOptions(
+        fun createOptions(isVisible: Boolean = true, isQuestion: Boolean = false, isDeleted: Boolean = false): ArticleOptions = ArticleOptions(
             isVisible = isVisible,
             isReported = false,
             isTrending = false,
             isQuestion = isQuestion,
-            isDeleted = false,
+            isDeleted = isDeleted,
         )
     }
 }

--- a/hunmin-domain/src/main/kotlin/com/domain/auth/Auth.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/auth/Auth.kt
@@ -24,5 +24,13 @@ class Auth(
             authPasswordEncryptor: AuthPasswordEncryptor,
             role: Role,
         ) = Auth(username = username, password = authPasswordEncryptor.encrypt(password), role = role)
+
+        fun anonymousAuth() =
+            Auth(
+                id = -1L,
+                username = "",
+                password = "",
+                role = Role.ANONYMOUS
+            )
     }
 }

--- a/hunmin-domain/src/main/kotlin/com/domain/auth/port/out/AuthRepositoryPort.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/auth/port/out/AuthRepositoryPort.kt
@@ -8,4 +8,6 @@ interface AuthRepositoryPort : AggregateRepository<Auth, Long> {
     fun findByUsername(username: String): Auth?
 
     fun existsByUsername(username: String): Boolean
+
+    fun existsById(id: Long): Boolean
 }

--- a/hunmin-domain/src/main/kotlin/com/domain/category/port/out/CategoryRepositoryPort.kt
+++ b/hunmin-domain/src/main/kotlin/com/domain/category/port/out/CategoryRepositoryPort.kt
@@ -6,4 +6,6 @@ import com.domain.category.Category
 interface CategoryRepositoryPort : AggregateRepository<Category, Long> {
 
     fun existsByTitle(title: String): Boolean
+
+    fun existsById(id: Long): Boolean
 }

--- a/hunmin-domain/src/test/kotlin/com/domain/article/ArticleTest.kt
+++ b/hunmin-domain/src/test/kotlin/com/domain/article/ArticleTest.kt
@@ -1,0 +1,142 @@
+package com.domain.article
+
+import com.common.global.exceptions.base.CustomException
+import com.domain.article.exception.ArticleExceptionType.ALREADY_DELETED_ARTICLE
+import com.domain.article.vo.ArticleOptions
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.assertj.core.api.Assertions.assertThatThrownBy
+
+class ArticleTest : BehaviorSpec({
+
+    Given("Article을 생성할 때") {
+
+        When("값이 주어지지 않으면") {
+            val article = Article(
+                title = "글 제목", content = "글 내용",
+                writerId = 1L, categoryId = 1L,
+                options = ArticleOptions(),
+            )
+
+            Then("id와 createdAt은 0이고, 옵션 정보는 초기화된다") {
+                assertSoftly {
+                    article.id shouldBe 0L
+                    article.title shouldBe "글 제목"
+                    article.content shouldBe "글 내용"
+                    article.writerId shouldBe 1L
+                    article.categoryId shouldBe 1L
+                    article.options.isVisible shouldBe true
+                    article.options.isReported shouldBe false
+                    article.options.isTrending shouldBe false
+                    article.options.isQuestion shouldBe false
+                    article.options.isDeleted shouldBe false
+                    article.createdAt shouldBe 0L
+                }
+            }
+        }
+
+        When("createArticle 메서드를 이용하면") {
+            val article = Article.createArticle(
+                title = "글 제목", content = "글 내용",
+                categoryId = 1L, writerId = 1L,
+                isVisible = true, isQuestion = false,
+            )
+
+            Then("해당 값으로 생성된다") {
+                assertSoftly {
+                    article.title shouldBe "글 제목"
+                    article.content shouldBe "글 내용"
+                    article.writerId shouldBe 1L
+                    article.categoryId shouldBe 1L
+                    article.options.isVisible shouldBe true
+                    article.options.isQuestion shouldBe false
+                }
+            }
+        }
+    }
+
+    Given("Article의 삭제 여부를 물어볼 때") {
+        val article = Article.createArticle(
+            title = "글 제목", content = "글 내용",
+            categoryId = 1L, writerId = 1L,
+            isVisible = true, isQuestion = false,
+        )
+
+        When("isDeleted를 호출하면") {
+            val articleOptions = article.options
+
+            Then("옵션의 삭제 여부와 같다") {
+                article.isDeleted() shouldBe articleOptions.isDeletedState()
+            }
+        }
+    }
+
+    Given("Article을 삭제할 때") {
+        val article = Article.createArticle(
+            title = "글 제목", content = "글 내용",
+            categoryId = 1L, writerId = 1L,
+            isVisible = true, isQuestion = false,
+        )
+
+        When("삭제되지 않았으면") {
+            val deletedArticle = article.delete()
+
+            Then("삭제 처리가 된 Article을 반환하고, 원래의 Article은 삭제되지 않는다") {
+                assertSoftly {
+                    article.isDeleted() shouldBe false
+                    deletedArticle.isDeleted() shouldBe true
+                }
+            }
+        }
+
+        When("이미 삭제되었으면") {
+            val deletedArticle = article.delete()
+
+            Then("예외가 발생한다") {
+                assertThatThrownBy {
+                    deletedArticle.delete()
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(ALREADY_DELETED_ARTICLE.message)
+            }
+        }
+    }
+
+    Given("Article을 수정할 때") {
+        val article = Article.createArticle(
+            title = "글 제목", content = "글 내용",
+            categoryId = 1L, writerId = 1L,
+            isVisible = true, isQuestion = false,
+        )
+
+        When("값이 주어지지 않으면") {
+            val updatedArticle = article.update()
+
+            Then("자신의 값과 같은 값을 가진 Article을 반환한다") {
+                updatedArticle shouldBeEqualToComparingFields article
+            }
+        }
+
+        When("값이 주어지면") {
+            val updatedArticle = article.update(
+                categoryId = 2L,
+                title = "글 제목 수정", content = "글 내용 수정",
+                isVisible = false,
+            )
+
+            Then("id, writerId, createdAt이 같은 Article을 반환한다") {
+                assertSoftly {
+                    article.id shouldBe updatedArticle.id
+                    article.title shouldNotBe updatedArticle.title
+                    article.content shouldNotBe updatedArticle.content
+                    article.writerId shouldBe updatedArticle.writerId
+                    article.categoryId shouldNotBe updatedArticle.categoryId
+                    article.options.isVisible shouldNotBe updatedArticle.options.isVisible
+                    article.createdAt shouldBe updatedArticle.createdAt
+                }
+            }
+        }
+    }
+})

--- a/hunmin-domain/src/test/kotlin/com/domain/article/ArticleTest.kt
+++ b/hunmin-domain/src/test/kotlin/com/domain/article/ArticleTest.kt
@@ -139,4 +139,23 @@ class ArticleTest : BehaviorSpec({
             }
         }
     }
+
+    Given("Article을 신고할 때") {
+        val article = Article.createArticle(
+            title = "글 제목", content = "글 내용",
+            categoryId = 1L, writerId = 1L,
+            isVisible = true, isQuestion = false,
+        )
+
+        When("신고 여부를 넘기면") {
+            val reportedArticle = article.updateReport(reportState = true)
+
+            Then("해당 상태로 변경된 새로운 Article을 반환한다") {
+                assertSoftly {
+                    reportedArticle.options.isReported shouldBe true
+                    article.options.isReported shouldBe false
+                }
+            }
+        }
+    }
 })

--- a/hunmin-domain/src/test/kotlin/com/domain/article/ArticleTest.kt
+++ b/hunmin-domain/src/test/kotlin/com/domain/article/ArticleTest.kt
@@ -14,30 +14,6 @@ class ArticleTest : BehaviorSpec({
 
     Given("Article을 생성할 때") {
 
-        When("값이 주어지지 않으면") {
-            val article = Article(
-                title = "글 제목", content = "글 내용",
-                writerId = 1L, categoryId = 1L,
-                options = ArticleOptions(),
-            )
-
-            Then("id와 createdAt은 0이고, 옵션 정보는 초기화된다") {
-                assertSoftly {
-                    article.id shouldBe 0L
-                    article.title shouldBe "글 제목"
-                    article.content shouldBe "글 내용"
-                    article.writerId shouldBe 1L
-                    article.categoryId shouldBe 1L
-                    article.options.isVisible shouldBe true
-                    article.options.isReported shouldBe false
-                    article.options.isTrending shouldBe false
-                    article.options.isQuestion shouldBe false
-                    article.options.isDeleted shouldBe false
-                    article.createdAt shouldBe 0L
-                }
-            }
-        }
-
         When("createArticle 메서드를 이용하면") {
             val article = Article.createArticle(
                 title = "글 제목", content = "글 내용",

--- a/hunmin-domain/src/test/kotlin/com/domain/article/vo/ArticleOptionsTest.kt
+++ b/hunmin-domain/src/test/kotlin/com/domain/article/vo/ArticleOptionsTest.kt
@@ -1,0 +1,124 @@
+package com.domain.article.vo
+
+import com.common.global.exceptions.base.CustomException
+import com.domain.article.exception.ArticleExceptionType.ALREADY_DELETED_ARTICLE
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.assertj.core.api.Assertions.assertThatThrownBy
+
+class ArticleOptionsTest : BehaviorSpec({
+
+    Given("ArticleOptions를 생성할 때") {
+
+        When("값이 주어지지 않으면") {
+            val articleOptions = ArticleOptions()
+
+            Then("기본값을 따른다") {
+                assertSoftly {
+                    articleOptions.isVisible shouldBe true
+                    articleOptions.isReported shouldBe false
+                    articleOptions.isTrending shouldBe false
+                    articleOptions.isQuestion shouldBe false
+                    articleOptions.isDeleted shouldBe false
+                }
+            }
+        }
+
+        When("createOptions 메서드를 이용하면") {
+            val articleOptions = ArticleOptions.createOptions(isVisible = true, isQuestion = true)
+
+            Then("해당 값을 이용하고 isReported, isTrending, isDeleted는 false 이다") {
+                assertSoftly {
+                    articleOptions.isVisible shouldBe true
+                    articleOptions.isReported shouldBe false
+                    articleOptions.isTrending shouldBe false
+                    articleOptions.isQuestion shouldBe true
+                    articleOptions.isDeleted shouldBe false
+                }
+            }
+        }
+    }
+
+    Given("ArticleOptions의 삭제 여부를 물어볼 때") {
+        val articleOptions = ArticleOptions.createOptions(isVisible = true, isQuestion = false)
+
+        When("isDeletedState 메서드를 이용하면") {
+
+            Then("삭제 여부를 알 수 있다") {
+                assertSoftly {
+                    articleOptions.isDeleted shouldBe false
+                    articleOptions.isDeletedState() shouldBe false
+                }
+            }
+        }
+    }
+
+    Given("ArticleOptions를 삭제할 때") {
+        val articleOptions = ArticleOptions.createOptions(isVisible = true, isQuestion = false)
+
+        When("삭제되지 않았으면") {
+            val deletedArticleOptions = articleOptions.delete()
+
+            Then("삭제 처리가 된 ArticleOptions를 반환하고, 원래의 삭제 여부는 변경되지 않는다") {
+                assertSoftly {
+                    articleOptions.isDeletedState() shouldBe false
+                    deletedArticleOptions.isDeletedState() shouldBe true
+                }
+            }
+        }
+
+        When("이미 삭제되었으면") {
+            val deletedArticleOptions = articleOptions.delete()
+
+            Then("예외가 발생한다") {
+                assertThatThrownBy {
+                    deletedArticleOptions.delete()
+                }.isInstanceOf(CustomException::class.java)
+                    .hasMessageContaining(ALREADY_DELETED_ARTICLE.message)
+            }
+        }
+    }
+
+    Given("ArticleOptions의 신고 여부를 변경할 때") {
+        val articleOptions = ArticleOptions.createOptions(isVisible = true, isQuestion = false)
+
+        When("reportState가 주어지면") {
+            val deletedArticleOptions = articleOptions.updateReport(reportState = true)
+
+            Then("해당 값으로 신고 여부가 설정된 ArticleOptions를 반환하고, 원래의 신고 여부는 변경되지 않는다") {
+                assertSoftly {
+                    deletedArticleOptions.isReported shouldBe true
+                    articleOptions.isReported shouldNotBe deletedArticleOptions.isReported
+                }
+            }
+        }
+    }
+
+    Given("ArticleOptions의 노출 여부를 변경할 때") {
+        val articleOptions = ArticleOptions.createOptions(isVisible = true, isQuestion = false)
+
+        When("값이 주어지지 않으면") {
+            val updatedArticleOptions = articleOptions.updateVisible()
+
+            Then("기존의 노출 여부와 같은 값을 가진 ArticleOptions를 반환한다") {
+                assertSoftly {
+                    articleOptions.isVisible shouldBe true
+                    updatedArticleOptions.isVisible shouldBe true
+                }
+            }
+        }
+
+        When("값이 주어지면") {
+            val updatedArticleOptions = articleOptions.updateVisible(isVisible = false)
+
+            Then("기존의 노출 여부와 반대 값을 가진 ArticleOptions를 반환하고, 기존의 노출 여부는 유지된다") {
+                assertSoftly {
+                    articleOptions.isVisible shouldBe true
+                    updatedArticleOptions.isVisible shouldBe false
+                }
+            }
+        }
+    }
+})

--- a/hunmin-domain/src/testFixtures/kotlin/com/domain/article/ArticleFixture.kt
+++ b/hunmin-domain/src/testFixtures/kotlin/com/domain/article/ArticleFixture.kt
@@ -1,0 +1,109 @@
+package com.domain.article
+
+import com.domain.article.dto.ArticleSimpleResponse
+import com.domain.article.dto.ArticlesSimpleResponse
+import com.domain.article.vo.ArticleOptions
+import java.time.Instant
+
+class ArticleFixture {
+    companion object {
+        fun 일반_글_생성() =
+            Article.createArticle(
+                title = "글 제목", content = "글 내용",
+                categoryId = 1L,
+                writerId = 0L,
+                isVisible = true,
+                isQuestion = false,
+            )
+
+        fun 일반_글_생성_신고처리(): Article {
+            val article = 일반_글_생성()
+            return article.updateReport(reportState = true)
+        }
+
+        fun 일반_글_생성_작성자id(writerId: Long) =
+            Article(
+                title = "글 제목",
+                content = "글 내용",
+                categoryId = 1L,
+                writerId = writerId,
+                options = ArticleOptions(),
+            )
+
+        fun 삭제_글_생성_작성자id(writerId: Long) =
+            Article(
+                title = "글 제목",
+                content = "글 내용",
+                categoryId = 1L,
+                writerId = writerId,
+                options = ArticleOptions(isDeleted = true),
+            )
+
+        fun 일반_글_응답_생성() =
+            ArticleSimpleResponse(
+                articleId = 1L,
+                title = "일반 글", content = "일반 글 내용",
+                writerId = 1L, writerName = "작성자",
+                categoryId = 1L, categoryName = "카테고리",
+                isVisible = true, isReported = false,
+                isTrending = false, isQuestion = false,
+                isDeleted = false, createdAt = Instant.ofEpochMilli(1000)
+            )
+
+        fun 삭제_글_응답_생성() =
+            ArticleSimpleResponse(
+                articleId = 1L,
+                title = "삭제 글", content = "삭제 글 내용",
+                writerId = 1L, writerName = "작성자",
+                categoryId = 1L, categoryName = "카테고리",
+                isVisible = false, isReported = false,
+                isTrending = false, isQuestion = false,
+                isDeleted = true, createdAt = Instant.ofEpochMilli(1000)
+            )
+
+        fun 숨김_글_응답_생성_작성자id(writerId: Long) =
+            ArticleSimpleResponse(
+                articleId = 1L,
+                title = "숨김 글", content = "숨김 글 내용",
+                writerId = writerId, writerName = "작성자",
+                categoryId = 1L, categoryName = "카테고리",
+                isVisible = false, isReported = false,
+                isTrending = false, isQuestion = false,
+                isDeleted = false, createdAt = Instant.ofEpochMilli(1000)
+            )
+
+        fun 일반_글_페이징_생성() =
+            ArticlesSimpleResponse(listOf(
+                ArticleSimpleResponse(
+                    articleId = 2L,
+                    title = "제목 2",
+                    content = "내용 2",
+                    writerId = 1L,
+                    writerName = "작성자",
+                    categoryId = 1L,
+                    categoryName = "카테고리",
+                    isVisible = true,
+                    isReported = false,
+                    isTrending = false,
+                    isQuestion = false,
+                    isDeleted = false,
+                    createdAt = Instant.ofEpochMilli(2000)
+                ),
+                ArticleSimpleResponse(
+                    articleId = 1L,
+                    title = "제목 1",
+                    content = "내용 1",
+                    writerId = 1L,
+                    writerName = "작성자",
+                    categoryId = 1L,
+                    categoryName = "카테고리",
+                    isVisible = true,
+                    isReported = false,
+                    isTrending = false,
+                    isQuestion = false,
+                    isDeleted = false,
+                    createdAt = Instant.ofEpochMilli(1000)
+                )
+            ))
+    }
+}

--- a/hunmin-domain/src/testFixtures/kotlin/com/domain/article/ArticleFixture.kt
+++ b/hunmin-domain/src/testFixtures/kotlin/com/domain/article/ArticleFixture.kt
@@ -22,21 +22,20 @@ class ArticleFixture {
         }
 
         fun 일반_글_생성_작성자id(writerId: Long) =
-            Article(
+            Article.createArticle(
                 title = "글 제목",
                 content = "글 내용",
                 categoryId = 1L,
                 writerId = writerId,
-                options = ArticleOptions(),
             )
 
         fun 삭제_글_생성_작성자id(writerId: Long) =
-            Article(
+            Article.createArticle(
                 title = "글 제목",
                 content = "글 내용",
                 categoryId = 1L,
                 writerId = writerId,
-                options = ArticleOptions(isDeleted = true),
+                isDeleted = true,
             )
 
         fun 일반_글_응답_생성() =

--- a/hunmin-infrastructure/adapter/src/main/kotlin/com/adapter/article/ArticleRepositoryAdapter.kt
+++ b/hunmin-infrastructure/adapter/src/main/kotlin/com/adapter/article/ArticleRepositoryAdapter.kt
@@ -1,0 +1,51 @@
+package com.adapter.article
+
+import com.common.global.exceptions.base.CustomException
+import com.domain.article.Article
+import com.domain.article.dto.ArticleSimpleResponse
+import com.domain.article.exception.ArticleExceptionType
+import com.domain.article.port.out.ArticleRepositoryPort
+import com.persistence.article.ArticleJpaRepository
+import com.persistence.article.ArticlePersistenceMapper
+import com.persistence.article.ArticleQueryRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+@Repository
+class ArticleRepositoryAdapter(
+    private val articleJpaRepositoryPort: ArticleJpaRepository,
+    private val articleQueryRepositoryPort: ArticleQueryRepository,
+    private val articlePersistenceMapper: ArticlePersistenceMapper,
+): ArticleRepositoryPort {
+
+    @Transactional
+    override fun save(aggregate: Article): Article {
+        val articleEntity = articlePersistenceMapper.toEntity(aggregate)
+        val savedArticle = articleJpaRepositoryPort.save(articleEntity)
+        return articlePersistenceMapper.toDomain(savedArticle)
+    }
+
+    override fun findByIdOrNull(id: Long): Article? =
+        articleJpaRepositoryPort.findByIdOrNull(id)
+            ?.let { articlePersistenceMapper.toDomain(it) }
+
+    override fun findArticleById(articleId: Long): ArticleSimpleResponse =
+        articleQueryRepositoryPort.findArticleById(articleId = articleId)
+            ?: throw CustomException(ArticleExceptionType.ARTICLE_NOT_FOUND)
+
+    override fun findArticleByQuery(
+        lastArticleId: Long?,
+        size: Int,
+        categories: List<Long>,
+        sort: String,
+        direction: String,
+        isQuestion: Boolean?,
+        isTrending: Boolean?,
+    ) =
+        articleQueryRepositoryPort.findArticlesByQuery(
+            lastArticleId = lastArticleId, size = size,
+            categories = categories, sort = sort, direction = direction, isQuestion = isQuestion, isTrending = isTrending,
+        )
+}

--- a/hunmin-infrastructure/adapter/src/main/kotlin/com/adapter/auth/AuthRepositoryAdapter.kt
+++ b/hunmin-infrastructure/adapter/src/main/kotlin/com/adapter/auth/AuthRepositoryAdapter.kt
@@ -33,4 +33,7 @@ class AuthRepositoryAdapter(
 
     override fun existsByUsername(username: String): Boolean =
         authJpaRepository.existsAuthByUsername(username)
+
+    override fun existsById(id: Long): Boolean =
+        authJpaRepository.existsById(id)
 }

--- a/hunmin-infrastructure/adapter/src/main/kotlin/com/adapter/category/CategoryRepositoryAdapter.kt
+++ b/hunmin-infrastructure/adapter/src/main/kotlin/com/adapter/category/CategoryRepositoryAdapter.kt
@@ -25,5 +25,9 @@ class CategoryRepositoryAdapter(
         categoryJpaRepository.findByIdOrNull(id)
             ?.let { categoryPersistenceMapper.toDomain(it) }
 
-    override fun existsByTitle(title: String): Boolean = categoryJpaRepository.existsCategoryByTitle(title)
+    override fun existsByTitle(title: String): Boolean =
+        categoryJpaRepository.existsCategoryByTitle(title)
+
+    override fun existsById(id: Long): Boolean =
+        categoryJpaRepository.existsById(id)
 }

--- a/hunmin-infrastructure/persistence/src/main/kotlin/com/persistence/article/ArticleJpaEntity.kt
+++ b/hunmin-infrastructure/persistence/src/main/kotlin/com/persistence/article/ArticleJpaEntity.kt
@@ -1,7 +1,9 @@
 package com.persistence.article
 
+import com.persistence.article.vo.ArticleOptions
 import com.persistence.global.BaseEntity
 import jakarta.persistence.Column
+import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -29,12 +31,6 @@ class ArticleJpaEntity(
     @Column(nullable = false)
     val writerId: Long,
 
-    @Column(nullable = false)
-    val isVisible: Boolean = true,
-
-    @Column(nullable = false)
-    val isBlamed: Boolean = false,
-
-    @Column(nullable = false)
-    val isQuestion: Boolean = false,
+    @Embedded
+    val options: ArticleOptions
 ) : BaseEntity()

--- a/hunmin-infrastructure/persistence/src/main/kotlin/com/persistence/article/ArticleJpaEntity.kt
+++ b/hunmin-infrastructure/persistence/src/main/kotlin/com/persistence/article/ArticleJpaEntity.kt
@@ -1,0 +1,40 @@
+package com.persistence.article
+
+import com.persistence.global.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Lob
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "article")
+class ArticleJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(nullable = false, length = 128)
+    val title: String,
+
+    @Lob
+    @Column(nullable = false)
+    val content: String,
+
+    @Column(nullable = false)
+    val categoryId: Long,
+
+    @Column(nullable = false)
+    val writerId: Long,
+
+    @Column(nullable = false)
+    val isVisible: Boolean = true,
+
+    @Column(nullable = false)
+    val isBlamed: Boolean = false,
+
+    @Column(nullable = false)
+    val isQuestion: Boolean = false,
+) : BaseEntity()

--- a/hunmin-infrastructure/persistence/src/main/kotlin/com/persistence/article/ArticleJpaRepository.kt
+++ b/hunmin-infrastructure/persistence/src/main/kotlin/com/persistence/article/ArticleJpaRepository.kt
@@ -1,0 +1,5 @@
+package com.persistence.article
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ArticleJpaRepository : JpaRepository<ArticleJpaEntity, Long>

--- a/hunmin-infrastructure/persistence/src/main/kotlin/com/persistence/article/ArticlePersistenceMapper.kt
+++ b/hunmin-infrastructure/persistence/src/main/kotlin/com/persistence/article/ArticlePersistenceMapper.kt
@@ -1,0 +1,41 @@
+package com.persistence.article
+
+import com.domain.article.Article
+import com.persistence.article.vo.ArticleOptions
+import org.springframework.stereotype.Component
+
+@Component
+class ArticlePersistenceMapper {
+    fun toEntity(article: Article) =
+            ArticleJpaEntity(
+                id = article.id,
+                title = article.title,
+                content = article.content,
+                categoryId = article.categoryId,
+                writerId = article.writerId,
+                options = ArticleOptions(
+                    isVisible = article.options.isVisible,
+                    isReported = article.options.isReported,
+                    isTrending = article.options.isTrending,
+                    isQuestion = article.options.isQuestion,
+                    isDeleted = article.options.isDeleted,
+                )
+            )
+
+    fun toDomain(entity: ArticleJpaEntity) =
+        Article(
+            id = entity.id,
+            title = entity.title,
+            content = entity.content,
+            writerId = entity.writerId,
+            categoryId = entity.categoryId,
+            options = com.domain.article.vo.ArticleOptions(
+                isVisible = entity.options.isVisible,
+                isReported = entity.options.isReported,
+                isTrending = entity.options.isTrending,
+                isQuestion = entity.options.isQuestion,
+                isDeleted = entity.options.isDeleted,
+            ),
+            createdAt = entity.createdAt.toEpochMilli(),
+        )
+}

--- a/hunmin-infrastructure/persistence/src/main/kotlin/com/persistence/article/ArticleQueryRepository.kt
+++ b/hunmin-infrastructure/persistence/src/main/kotlin/com/persistence/article/ArticleQueryRepository.kt
@@ -52,13 +52,10 @@ class ArticleQueryRepository(
     ): ArticlesSimpleResponse {
         val sortOrder = if (direction.equals("DESC", ignoreCase = true)) Order.DESC else Order.ASC
 
-        val orderSpecifier = when (sort) {
-            "createdAt" -> com.querydsl.core.types.dsl.Expressions.stringPath("createdAt").let {
-                OrderSpecifier(sortOrder, articleJpaEntity.createdAt)
-            }
-            "isTrending" -> OrderSpecifier(sortOrder, articleJpaEntity.options.isTrending)
-            else -> OrderSpecifier(Order.DESC, articleJpaEntity.createdAt)
-        }
+        val orderSpecifier = listOf(
+            OrderSpecifier(sortOrder, articleJpaEntity.options.isTrending),
+            OrderSpecifier(Order.DESC, articleJpaEntity.createdAt)
+        )
 
         val results = jpaQueryFactory
             .select(
@@ -86,9 +83,11 @@ class ArticleQueryRepository(
                 isQuestion?.let { articleJpaEntity.options.isQuestion.eq(isQuestion)},
                 isTrending?.let { articleJpaEntity.options.isTrending.eq(isTrending)},
                 articleJpaEntity.categoryId.`in`(categories),
+                articleJpaEntity.options.isDeleted.eq(false),
+                articleJpaEntity.options.isVisible.eq(true),
                 lastArticleId?.let { articleJpaEntity.id.lt(it) }
             )
-            .orderBy(orderSpecifier)
+            .orderBy(*orderSpecifier.toTypedArray())
             .limit(size.toLong())
             .fetch()
 

--- a/hunmin-infrastructure/persistence/src/main/kotlin/com/persistence/article/ArticleQueryRepository.kt
+++ b/hunmin-infrastructure/persistence/src/main/kotlin/com/persistence/article/ArticleQueryRepository.kt
@@ -1,0 +1,97 @@
+package com.persistence.article
+
+import com.domain.article.dto.ArticleSimpleResponse
+import com.domain.article.dto.ArticlesSimpleResponse
+import com.persistence.article.QArticleJpaEntity.articleJpaEntity
+import com.persistence.auth.QAuthJpaEntity.authJpaEntity
+import com.persistence.category.QCategoryJpaEntity.categoryJpaEntity
+import com.querydsl.core.types.Order
+import com.querydsl.core.types.OrderSpecifier
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+
+@Repository
+class ArticleQueryRepository(
+    private val jpaQueryFactory: JPAQueryFactory,
+) {
+    fun findArticleById(articleId: Long): ArticleSimpleResponse? =
+        jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    ArticleSimpleResponse::class.java,
+                    articleJpaEntity.id,
+                    articleJpaEntity.title,
+                    articleJpaEntity.content,
+                    articleJpaEntity.writerId,
+                    authJpaEntity.username,
+                    articleJpaEntity.categoryId,
+                    categoryJpaEntity.title,
+                    articleJpaEntity.options.isVisible,
+                    articleJpaEntity.options.isReported,
+                    articleJpaEntity.options.isTrending,
+                    articleJpaEntity.options.isQuestion,
+                    articleJpaEntity.options.isDeleted,
+                    articleJpaEntity.createdAt,
+                )
+            )
+            .from(articleJpaEntity)
+            .join(authJpaEntity).on(articleJpaEntity.writerId.eq(authJpaEntity.id))
+            .join(categoryJpaEntity).on(articleJpaEntity.categoryId.eq(categoryJpaEntity.id))
+            .where(articleJpaEntity.id.eq(articleId))
+            .fetchOne()
+
+    fun findArticlesByQuery(
+        lastArticleId: Long?,
+        size: Int,
+        categories: List<Long>,
+        sort: String,
+        direction: String,
+        isQuestion: Boolean?,
+        isTrending: Boolean?,
+    ): ArticlesSimpleResponse {
+        val sortOrder = if (direction.equals("DESC", ignoreCase = true)) Order.DESC else Order.ASC
+
+        val orderSpecifier = when (sort) {
+            "createdAt" -> com.querydsl.core.types.dsl.Expressions.stringPath("createdAt").let {
+                OrderSpecifier(sortOrder, articleJpaEntity.createdAt)
+            }
+            "isTrending" -> OrderSpecifier(sortOrder, articleJpaEntity.options.isTrending)
+            else -> OrderSpecifier(Order.DESC, articleJpaEntity.createdAt)
+        }
+
+        val results = jpaQueryFactory
+            .select(
+                Projections.constructor(
+                    ArticleSimpleResponse::class.java,
+                    articleJpaEntity.id,
+                    articleJpaEntity.title,
+                    articleJpaEntity.content,
+                    articleJpaEntity.writerId,
+                    authJpaEntity.username,
+                    articleJpaEntity.categoryId,
+                    categoryJpaEntity.title,
+                    articleJpaEntity.options.isVisible,
+                    articleJpaEntity.options.isReported,
+                    articleJpaEntity.options.isTrending,
+                    articleJpaEntity.options.isQuestion,
+                    articleJpaEntity.options.isDeleted,
+                    articleJpaEntity.createdAt
+                )
+            )
+            .from(articleJpaEntity)
+            .join(authJpaEntity).on(articleJpaEntity.writerId.eq(authJpaEntity.id))
+            .join(categoryJpaEntity).on(articleJpaEntity.categoryId.eq(categoryJpaEntity.id))
+            .where(
+                isQuestion?.let { articleJpaEntity.options.isQuestion.eq(isQuestion)},
+                isTrending?.let { articleJpaEntity.options.isTrending.eq(isTrending)},
+                articleJpaEntity.categoryId.`in`(categories),
+                lastArticleId?.let { articleJpaEntity.id.lt(it) }
+            )
+            .orderBy(orderSpecifier)
+            .limit(size.toLong())
+            .fetch()
+
+        return ArticlesSimpleResponse(articles = results)
+    }
+}

--- a/hunmin-infrastructure/persistence/src/main/kotlin/com/persistence/article/vo/ArticleOptions.kt
+++ b/hunmin-infrastructure/persistence/src/main/kotlin/com/persistence/article/vo/ArticleOptions.kt
@@ -1,0 +1,22 @@
+package com.persistence.article.vo
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class ArticleOptions(
+    @Column(nullable = false)
+    val isVisible: Boolean = true,
+
+    @Column(nullable = false)
+    val isReported: Boolean = false,
+
+    @Column(nullable = false)
+    val isTrending: Boolean = false,
+
+    @Column(nullable = false)
+    val isQuestion: Boolean = false,
+
+    @Column(nullable = false)
+    val isDeleted: Boolean = false,
+)


### PR DESCRIPTION
## 📄 Summary
port를 도메인에서 application으로 올리는 건 다른 이슈해서 해야 할 듯 합니다.

## 🙋🏻 More

현재 MVP로 설계한 방향은 아래와 같습니다.

* 생성
  * 연관된 카테고리 조회 실패 시 예외
* 신고
  * 신고 처리할 수 있음 (신고 처리 시 사유 필수 기재)
  * 어드민만 접근 가능
  * 신고된 걸 해제하는 것도 가능
* 삭제
  * 일반 유저면서 작성자가 아니면 예외
  * 어드민이면 작성자가 아니더라도 삭제 처리 (soft delete)
* 수정
  * 일반 유저이면서 작성자가 아니면 예외
  * 삭제된 상태면 작성자더라도 예외 (어드민 제외)
* 단건 조회
  * 익명도 조회 가능
* 목록 조회
  * 익명도 조회 가능
  * 여러 조건을 통해 목록 조회 가능, No Offset 기반


close #23